### PR TITLE
Remove missing docs links and minimize release branch prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ plane and adds the following new functionality:
   etc.)
 * Controllers to provision these resources in Azure based on the users desired
   state captured in CRDs they create
-* Implementations of Crossplane's [portable resource
-  abstractions](https://crossplane.io/docs/master/concepts.html), enabling Azure
+* Implementations of Crossplane's portable resource abstractions, enabling Azure
   resources to fulfill a user's general need for cloud services
 
 ## Getting Started and Documentation

--- a/config/stack/manifests/app.yaml
+++ b/config/stack/manifests/app.yaml
@@ -12,7 +12,7 @@ readme: |
 
  * Custom Resource Definitions (CRDs) that model Azure infrastructure and services (e.g. [Azure Database for MySQL](https://azure.microsoft.com/en-us/services/mysql/), [AKS clusters](https://azure.microsoft.com/en-us/services/kubernetes-service/), etc.)
  * Controllers to provision these resources in Azure based on the users desired state captured in CRDs they create
- * Implementations of Crossplane's [portable resource abstractions](https://crossplane.io/docs/master/concepts.html), enabling Azure resources to fulfill a user's general need for cloud services
+ * Implementations of Crossplane's portable resource abstractions, enabling Azure resources to fulfill a user's general need for cloud services
 
 # Maintainer names and emails.
 maintainers:

--- a/config/stack/manifests/resources/accountclass.resource.yaml
+++ b/config/stack/manifests/resources/accountclass.resource.yaml
@@ -8,4 +8,4 @@ overview: |
 readme: |
  Cloud-specific resource classes are used to define a reusable configuration for a specific managed service. This class provides a storage account, which is satisfied by [Azure Blob Storage Accounts](https://docs.microsoft.com/en-us/azure/storage/common/storage-account-overview).
 
- Full documentation can be found in the Crossplane [API Reference docs](https://crossplane.io/docs/master/api/crossplane/provider-azure/storage-azure-crossplane-io-v1alpha3.html#AccountClass).
+ Full documentation can be found in the Crossplane [API Reference docs](https://doc.crds.dev/github.com/crossplane/provider-azure/storage.azure.crossplane.io_accountclasses.yaml).

--- a/config/stack/manifests/resources/aksclusterclass.resource.yaml
+++ b/config/stack/manifests/resources/aksclusterclass.resource.yaml
@@ -8,4 +8,4 @@ overview: |
 readme: |
  Cloud-specific resource classes are used to define a reusable configuration for a specific managed service. This class provides a managed Kubernetes cluster, which is satisfied by [Azure Kubernetes Service](https://docs.microsoft.com/en-us/azure/aks/).
 
- Full documentation can be found in the Crossplane [API Reference docs](https://crossplane.io/docs/master/api/crossplane/provider-azure/compute-azure-crossplane-io-v1alpha3.html#AKSClusterClass).
+ Full documentation can be found in the Crossplane [API Reference docs](https://doc.crds.dev/github.com/crossplane/provider-azure/compute.azure.crossplane.io_aksclusterclasses.yaml).

--- a/config/stack/manifests/resources/containerclass.resource.yaml
+++ b/config/stack/manifests/resources/containerclass.resource.yaml
@@ -8,4 +8,4 @@ overview: |
 readme: |
  Cloud-specific resource classes are used to define a reusable configuration for a specific managed service. This class provides object storage buckets, which are satisfied by [Azure Blob Storage](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blobs-introduction).
 
- Full documentation can be found in the Crossplane [API Reference docs](https://crossplane.io/docs/master/api/crossplane/provider-azure/storage-azure-crossplane-io-v1alpha3.html#ContainerClass).
+ Full documentation can be found in the Crossplane [API Reference docs](https://doc.crds.dev/github.com/crossplane/provider-azure/storage.azure.crossplane.io_containerclasses.yaml).

--- a/config/stack/manifests/resources/redisclass.resource.yaml
+++ b/config/stack/manifests/resources/redisclass.resource.yaml
@@ -8,4 +8,4 @@ overview: |
 readme: |
  Cloud-specific resource classes are used to define a reusable configuration for a specific managed service. This class provides Redis caches, which are satisfied by [Azure Cache for Redis](https://azure.microsoft.com/en-us/services/cache/).
 
- Full documentation can be found in the Crossplane [API Reference docs](https://crossplane.io/docs/master/api/crossplane/provider-azure/compute-azure-crossplane-io-v1alpha3.html#SQLServerClass).
+ Full documentation can be found in the Crossplane [API Reference docs](https://doc.crds.dev/github.com/crossplane/provider-azure/cache.azure.crossplane.io_redisclasses.yaml).

--- a/config/stack/manifests/resources/sqlserverclass.resource.yaml
+++ b/config/stack/manifests/resources/sqlserverclass.resource.yaml
@@ -8,4 +8,4 @@ overview: |
 readme: |
  Cloud-specific resource classes are used to define a reusable configuration for a specific managed service. This class provides MySQL and PostgreSQL databases, which are satisfied by [Azure Database for MySQL](https://azure.microsoft.com/en-us/services/mysql/) and [Azure Database for PostgreSQL](https://azure.microsoft.com/en-us/services/postgresql/).
 
- Full documentation can be found in the Crossplane [API Reference docs](https://crossplane.io/docs/master/api/crossplane/provider-azure/compute-azure-crossplane-io-v1alpha3.html#SQLServerClass).
+ Full documentation can be found in the Crossplane [API Reference docs](https://doc.crds.dev/github.com/crossplane/provider-azure/database.azure.crossplane.io_sqlserverclasses.yaml).


### PR DESCRIPTION
Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

The `portable resource abstractions` link no longer exists (this change was already made in release). The docs api references no longer exist on `master` and the `v0.7` release was the last one in which they did. These changes also remove almost all updates required in our branch prep PRs.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the dependencies in [`app.yaml`] to include any new role permissions.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplane/provider-azure/blob/master/config/stack/manifests/app.yaml