### PR TITLE
Don't delete resource groups that are already deleting

### DIFF
--- a/apis/v1alpha3/types.go
+++ b/apis/v1alpha3/types.go
@@ -22,6 +22,15 @@ import (
 	runtimev1alpha1 "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
 )
 
+// A ProvisioningState of a resource group.
+type ProvisioningState string
+
+// Provisioning states.
+const (
+	ProvisioningStateSucceeded ProvisioningState = "Succeeded"
+	ProvisioningStateDeleting  ProvisioningState = "Deleting"
+)
+
 // A ProviderSpec defines the desired state of a Provider.
 type ProviderSpec struct {
 	runtimev1alpha1.ProviderSpec `json:",inline"`
@@ -61,6 +70,9 @@ type ResourceGroupSpec struct {
 // A ResourceGroupStatus represents the observed status of a ResourceGroup.
 type ResourceGroupStatus struct {
 	runtimev1alpha1.ResourceStatus `json:",inline"`
+
+	// ProvisioningState - The provisioning state of the resource group.
+	ProvisioningState ProvisioningState `json:"provisioningState,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/azure.crossplane.io_resourcegroups.yaml
+++ b/config/crd/azure.crossplane.io_resourcegroups.yaml
@@ -238,6 +238,10 @@ spec:
                 - type
                 type: object
               type: array
+            provisioningState:
+              description: ProvisioningState - The provisioning state of the resource
+                group.
+              type: string
           type: object
       required:
       - spec

--- a/pkg/clients/resourcegroup/fake/fake.go
+++ b/pkg/clients/resourcegroup/fake/fake.go
@@ -33,6 +33,7 @@ type MockClient struct {
 	MockCreateOrUpdate func(ctx context.Context, resourceGroupName string, parameters resources.Group) (result resources.Group, err error)
 	MockCheckExistence func(ctx context.Context, resourceGroupName string) (result autorest.Response, err error)
 	MockDelete         func(ctx context.Context, resourceGroupName string) (result resources.GroupsDeleteFuture, err error)
+	MockGet            func(ctx context.Context, resourceGroupName string) (result resources.Group, err error)
 }
 
 // CreateOrUpdate calls the underlying MockCreateOrUpdate method.
@@ -48,4 +49,9 @@ func (m *MockClient) CheckExistence(ctx context.Context, resourceGroupName strin
 // Delete calls the underlying MockDeleteGroup method.
 func (m *MockClient) Delete(ctx context.Context, resourceGroupName string) (result resources.GroupsDeleteFuture, err error) {
 	return m.MockDelete(ctx, resourceGroupName)
+}
+
+// Get calls the underlying MockGet method.
+func (m *MockClient) Get(ctx context.Context, resourceGroupName string) (result resources.Group, err error) {
+	return m.MockGet(ctx, resourceGroupName)
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->
It seems that calling delete on a resource group extends the time required to delete the group; presumably some deletion process is restarted? This results in the resource group never actually being deleted.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the dependencies in [`app.yaml`] to include any new role permissions.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplane/provider-azure/blob/master/config/stack/manifests/app.yaml