### PR TITLE
Fix already exists error in SQL resources

### DIFF
--- a/pkg/clients/database/mysql.go
+++ b/pkg/clients/database/mysql.go
@@ -56,7 +56,6 @@ var (
 
 // MySQLServerAPI represents the API interface for a MySQL Server client
 type MySQLServerAPI interface {
-	ServerNameTaken(ctx context.Context, s *azuredbv1beta1.MySQLServer) (bool, error)
 	GetServer(ctx context.Context, s *azuredbv1beta1.MySQLServer) (mysql.Server, error)
 	CreateServer(ctx context.Context, s *azuredbv1beta1.MySQLServer, adminPassword string) error
 	UpdateServer(ctx context.Context, s *azuredbv1beta1.MySQLServer) error

--- a/pkg/clients/database/postgresql.go
+++ b/pkg/clients/database/postgresql.go
@@ -49,7 +49,6 @@ import (
 
 // PostgreSQLServerAPI represents the API interface for a PostgreSQL Server client
 type PostgreSQLServerAPI interface {
-	ServerNameTaken(ctx context.Context, s *azuredbv1beta1.PostgreSQLServer) (bool, error)
 	GetServer(ctx context.Context, s *azuredbv1beta1.PostgreSQLServer) (postgresql.Server, error)
 	CreateServer(ctx context.Context, s *azuredbv1beta1.PostgreSQLServer, adminPassword string) error
 	DeleteServer(ctx context.Context, s *azuredbv1beta1.PostgreSQLServer) error
@@ -86,15 +85,6 @@ func NewPostgreSQLServerClient(c *azure.Client) (*PostgreSQLServerClient, error)
 // GetRESTClient returns the underlying REST client that the client object uses.
 func (c *PostgreSQLServerClient) GetRESTClient() autorest.Sender {
 	return c.ServersClient.Client
-}
-
-// ServerNameTaken returns true if the supplied server's name has been taken.
-func (c *PostgreSQLServerClient) ServerNameTaken(ctx context.Context, s *azuredbv1beta1.PostgreSQLServer) (bool, error) {
-	r, err := c.Execute(ctx, postgresql.NameAvailabilityRequest{Name: azure.ToStringPtr(meta.GetExternalName(s))})
-	if err != nil {
-		return false, err
-	}
-	return !azure.ToBool(r.NameAvailable), nil
 }
 
 // GetServer retrieves the requested PostgreSQL Server

--- a/pkg/controller/database/postgresqlserver/managed.go
+++ b/pkg/controller/database/postgresqlserver/managed.go
@@ -42,19 +42,18 @@ import (
 
 // Error strings.
 const (
-	errNewClient                 = "cannot create new PostgreSQLServer client"
-	errGetProvider               = "cannot get Azure provider"
-	errGetProviderSecret         = "cannot get Azure provider Secret"
-	errProviderSecretNil         = "Azure provider does not have a secret reference"
-	errUpdateCR                  = "cannot update PostgreSQL custom resource"
-	errGenPassword               = "cannot generate admin password"
-	errNotPostgreSQLServer       = "managed resource is not a PostgreSQLServer"
-	errCreatePostgreSQLServer    = "cannot create PostgreSQLServer"
-	errUpdatePostgreSQLServer    = "cannot update PostgreSQLServer"
-	errGetPostgreSQLServer       = "cannot get PostgreSQLServer"
-	errDeletePostgreSQLServer    = "cannot delete PostgreSQLServer"
-	errCheckPostgreSQLServerName = "cannot check PostgreSQLServer name availability"
-	errFetchLastOperation        = "cannot fetch last operation"
+	errNewClient              = "cannot create new PostgreSQLServer client"
+	errGetProvider            = "cannot get Azure provider"
+	errGetProviderSecret      = "cannot get Azure provider Secret"
+	errProviderSecretNil      = "Azure provider does not have a secret reference"
+	errUpdateCR               = "cannot update PostgreSQL custom resource"
+	errGenPassword            = "cannot generate admin password"
+	errNotPostgreSQLServer    = "managed resource is not a PostgreSQLServer"
+	errCreatePostgreSQLServer = "cannot create PostgreSQLServer"
+	errUpdatePostgreSQLServer = "cannot update PostgreSQLServer"
+	errGetPostgreSQLServer    = "cannot get PostgreSQLServer"
+	errDeletePostgreSQLServer = "cannot delete PostgreSQLServer"
+	errFetchLastOperation     = "cannot fetch last operation"
 )
 
 // Setup adds a controller that reconciles PostgreSQLInstances.
@@ -123,17 +122,15 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	}
 	server, err := e.client.GetServer(ctx, cr)
 	if azure.IsNotFound(err) {
-		// Azure SQL servers don't exist according to the Azure API until their
-		// create operation has completed, and Azure will happily let you submit
-		// several subsequent create operations for the same server. Our create
-		// call is not idempotent because it creates a new random password each
-		// time, so we want to ensure it's only called once. Fortunately Azure
-		// exposes an API that reports server names to be taken as soon as their
-		// create operation is accepted.
-		creating, err := e.client.ServerNameTaken(ctx, cr)
-		if err != nil {
-			return managed.ExternalObservation{}, errors.Wrap(err, errCheckPostgreSQLServerName)
+		if err := azure.FetchAsyncOperation(ctx, e.client.GetRESTClient(), &cr.Status.AtProvider.LastOperation); err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, errFetchLastOperation)
 		}
+		// Azure returns NotFound for GET calls until creation is completed
+		// successfully and we cannot return `ResourceExists: false` during creation
+		// since this will cause `Create` to be called again and it's not idempotent.
+		// So, we check whether a creation operation in fact is in motion.
+		creating := cr.Status.AtProvider.LastOperation.Method == "PUT" &&
+			cr.Status.AtProvider.LastOperation.Status == azure.AsyncOperationStatusInProgress
 		return managed.ExternalObservation{ResourceExists: creating}, nil
 	}
 	if err != nil {

--- a/pkg/controller/database/postgresqlserver/managed_test.go
+++ b/pkg/controller/database/postgresqlserver/managed_test.go
@@ -395,8 +395,6 @@ func TestObserve(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			ola := name
-			fmt.Print(ola)
 			eo, err := tc.e.Observe(tc.args.ctx, tc.args.mg)
 
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

Azure MySQLServer API allows calling `Create` multiple times and it returns `NotFound` until the server is created successfully. We can't call `Create` multiple times until we see the resource because it'd generate a different password but we don't know whether a creation is in progress either. How we worked around this has been checking the name availability of the MySQL server; if it's not available then it's in creation. But this is not a viable solution since we never return error if in fact a completely different MySQL Server exists with the same name but in a different resource group, meaning we can't take over control but we don't return an error either. What happens is that `Update` fails because it cannot find that SQL Server in that specific `ResourceGroup` like the following:
```
update failed: cannot update PostgreSQLServer: postgresql.ServersClient#Update: Failure sending request: StatusCode=404 -- Original Error: Code="ResourceNotFound" Message="The Resource 'Microsoft.DBforPostgreSQL/servers/sqlserverpostgresql' under resource group 'sqlserverpostgresql-rg' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix"
```
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->
Fixes https://github.com/crossplane/provider-azure/issues/160

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the dependencies in [`app.yaml`] to include any new role permissions.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplane/provider-azure/blob/master/config/package/manifests/app.yaml