### PR TITLE
Remove references to reclaim policy and resource classes

### DIFF
--- a/apis/storage/v1alpha3/test/account.go
+++ b/apis/storage/v1alpha3/test/account.go
@@ -83,7 +83,7 @@ func (ta *MockAccount) WithSpecProvider(name string) *MockAccount {
 	return ta
 }
 
-// WithSpecDeletionPolicy sets resource reclaim policy
+// WithSpecDeletionPolicy sets resource deletion policy
 func (ta *MockAccount) WithSpecDeletionPolicy(policy runtimev1alpha1.DeletionPolicy) *MockAccount {
 	ta.Spec.DeletionPolicy = policy
 	return ta

--- a/apis/storage/v1alpha3/types.go
+++ b/apis/storage/v1alpha3/types.go
@@ -52,7 +52,6 @@ type AccountStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="RESOURCE_GROUP",type="string",JSONPath=".spec.resourceGroupName"
 // +kubebuilder:printcolumn:name="ACCOUNT_NAME",type="string",JSONPath=".spec.storageAccountName"
-// +kubebuilder:printcolumn:name="CLASS",type="string",JSONPath=".spec.classRef.name"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,azure}
 type Account struct {

--- a/examples/cache/redis.yaml
+++ b/examples/cache/redis.yaml
@@ -16,7 +16,6 @@ specTemplate:
     enableNonSslPort: true
   providerConfigRef:
     name: example
-  reclaimPolicy: Delete
   writeConnectionSecretsToRef:
     name: example-cache
     namespace: crossplane-system

--- a/examples/compute/akscluster.yaml
+++ b/examples/compute/akscluster.yaml
@@ -18,5 +18,4 @@ spec:
   disableRBAC: false
   providerConfigRef:
     name: example
-  reclaimPolicy: Delete
   writeConnectionSecretsToNamespace: crossplane-system

--- a/examples/database/cosmosdbaccount.yaml
+++ b/examples/database/cosmosdbaccount.yaml
@@ -18,7 +18,6 @@ spec:
           isZoneRedundant: false
   providerConfigRef:
     name: example
-  reclaimPolicy: Retain
   writeConnectionSecretToRef:
     namespace: crossplane-system
     name: example-cdb

--- a/examples/database/mysqlserver.yaml
+++ b/examples/database/mysqlserver.yaml
@@ -25,4 +25,3 @@ spec:
     name: example-mysql
   providerConfigRef:
     name: example
-  reclaimPolicy: Delete

--- a/examples/database/postgresqlserver.yaml
+++ b/examples/database/postgresqlserver.yaml
@@ -25,4 +25,3 @@ spec:
     name: example-psql
   providerConfigRef:
     name: example
-  reclaimPolicy: Delete

--- a/examples/network/subnet.yaml
+++ b/examples/network/subnet.yaml
@@ -11,6 +11,5 @@ spec:
     addressPrefix: 10.2.0.0/24
     serviceEndpoints:
       - service: Microsoft.Sql
-  reclaimPolicy: Delete
   providerConfigRef:
     name: example

--- a/examples/network/virtualnetwork.yaml
+++ b/examples/network/virtualnetwork.yaml
@@ -10,6 +10,5 @@ spec:
     addressSpace:
       addressPrefixes:
         - 10.2.0.0/16
-  reclaimPolicy: Delete
   providerConfigRef:
     name: example

--- a/examples/storage/account.yaml
+++ b/examples/storage/account.yaml
@@ -16,7 +16,6 @@ spec:
       application: crossplane
   providerConfigRef:
     name: example
-  reclaimPolicy: Delete
   writeConnectionSecretToRef:
     namespace: crossplane-system
     name: exampleacc

--- a/examples/storage/container.yaml
+++ b/examples/storage/container.yaml
@@ -12,4 +12,3 @@ specTemplate:
   # use the providerRef field to specify which Account to read credentials from.
   providerConfigRef:
     name: exampleacc
-  reclaimPolicy: Delete

--- a/package/crds/storage.azure.crossplane.io_accounts.yaml
+++ b/package/crds/storage.azure.crossplane.io_accounts.yaml
@@ -13,9 +13,6 @@ spec:
   - JSONPath: .spec.storageAccountName
     name: ACCOUNT_NAME
     type: string
-  - JSONPath: .spec.classRef.name
-    name: CLASS
-    type: string
   - JSONPath: .metadata.creationTimestamp
     name: AGE
     type: date

--- a/pkg/controller/storage/container/container_test.go
+++ b/pkg/controller/storage/container/container_test.go
@@ -501,7 +501,7 @@ func Test_containerSyncdeleter_delete(t *testing.T) {
 		want   want
 	}{
 		{
-			name: "ReclaimRetain",
+			name: "DeletionOrphan",
 			fields: fields{
 				kube: test.NewMockClient(),
 				container: v1alpha3test.NewMockContainer(testContainerName).


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Removes all references to reclaimPolicy, which has been replaced by deletionPolicy, and resource classes, which have been removed.

xref crossplane/crossplane#1781

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

`make generate`
`make reviewable`

[contribution process]: https://git.io/fj2m9
