### PR TITLE
Permit restoring mysql/postgresql DBs

### DIFF
--- a/apis/database/v1beta1/sql_types.go
+++ b/apis/database/v1beta1/sql_types.go
@@ -163,7 +163,17 @@ type SQLServerParameters struct {
 
 	// TODO(hasheddan): support PublicNetworkAccess
 
-	// TODO(hasheddan): support CreateMode
+	// CreateMode - Possible values include: 'CreateModeDefault', 'CreateModePointInTimeRestore', 'CreateModeGeoRestore', 'CreateModeReplica'
+	// +optional
+	CreateMode *CreateMode `json:"createMode,omitempty"`
+
+	// RestorePointInTime - Restore point creation time (RFC3339 format), specifying the time to restore from.
+	// +optional
+	RestorePointInTime *metav1.Time `json:"restorePointInTime,omitempty"`
+
+	// SourceServerID - The server to restore from when restoring or creating replicas
+	// +optional
+	SourceServerID *string `json:"sourceServerID,omitempty"`
 
 	// Tags - Application-specific metadata in the form of key-value pairs.
 	// +optional
@@ -191,6 +201,19 @@ const (
 	TLS11                  MinimalTLSVersionEnum = "TLS1_1"
 	TLS12                  MinimalTLSVersionEnum = "TLS1_2"
 	TLSEnforcementDisabled MinimalTLSVersionEnum = "TLSEnforcementDisabled"
+)
+
+// CreateMode controls the creation behaviour
+// Keep synced with "github.com/Azure/azure-sdk-for-go/services/postgresql/mgmt/2017-12-01/postgresql".MinimalTLSVersionEnum
+// +kubebuilder:validation:Enum=Default;GeoRestore;PointInTimeRestore;Replica
+type CreateMode string
+
+// All valid values of CreateMode
+const (
+	CreateModeDefault            CreateMode = "Default"
+	CreateModeReplica            CreateMode = "Replica"
+	CreateModeGeoRestore         CreateMode = "GeoRestore"
+	CreateModePointInTimeRestore CreateMode = "PointInTimeRestore"
 )
 
 // A SQLServerSpec defines the desired state of a SQLServer.

--- a/apis/database/v1beta1/zz_generated.deepcopy.go
+++ b/apis/database/v1beta1/zz_generated.deepcopy.go
@@ -193,6 +193,20 @@ func (in *SQLServerParameters) DeepCopyInto(out *SQLServerParameters) {
 		(*in).DeepCopyInto(*out)
 	}
 	in.SKU.DeepCopyInto(&out.SKU)
+	if in.CreateMode != nil {
+		in, out := &in.CreateMode, &out.CreateMode
+		*out = new(CreateMode)
+		**out = **in
+	}
+	if in.RestorePointInTime != nil {
+		in, out := &in.RestorePointInTime, &out.RestorePointInTime
+		*out = (*in).DeepCopy()
+	}
+	if in.SourceServerID != nil {
+		in, out := &in.SourceServerID, &out.SourceServerID
+		*out = new(string)
+		**out = **in
+	}
 	if in.Tags != nil {
 		in, out := &in.Tags, &out.Tags
 		*out = make(map[string]string, len(*in))

--- a/package/crds/database.azure.crossplane.io_mysqlservers.yaml
+++ b/package/crds/database.azure.crossplane.io_mysqlservers.yaml
@@ -59,6 +59,14 @@ spec:
                   administratorLogin:
                     description: AdministratorLogin - The administrator's login name of a server. Can only be specified when the server is being created (and is required for creation).
                     type: string
+                  createMode:
+                    description: 'CreateMode - Possible values include: ''CreateModeDefault'', ''CreateModePointInTimeRestore'', ''CreateModeGeoRestore'', ''CreateModeReplica'''
+                    enum:
+                    - Default
+                    - GeoRestore
+                    - PointInTimeRestore
+                    - Replica
+                    type: string
                   location:
                     description: Location specifies the location of this SQLServer.
                     type: string
@@ -94,6 +102,10 @@ spec:
                         description: MatchLabels ensures an object with matching labels is selected.
                         type: object
                     type: object
+                  restorePointInTime:
+                    description: RestorePointInTime - Restore point creation time (RFC3339 format), specifying the time to restore from.
+                    format: date-time
+                    type: string
                   sku:
                     description: SKU is the billing information related properties of the server.
                     properties:
@@ -118,6 +130,9 @@ spec:
                     - family
                     - tier
                     type: object
+                  sourceServerID:
+                    description: SourceServerID - The server to restore from when restoring or creating replicas
+                    type: string
                   sslEnforcement:
                     description: 'SSLEnforcement - Enable ssl enforcement or not when connect to server. Possible values include: ''Enabled'', ''Disabled'''
                     enum:

--- a/package/crds/database.azure.crossplane.io_postgresqlservers.yaml
+++ b/package/crds/database.azure.crossplane.io_postgresqlservers.yaml
@@ -59,6 +59,14 @@ spec:
                   administratorLogin:
                     description: AdministratorLogin - The administrator's login name of a server. Can only be specified when the server is being created (and is required for creation).
                     type: string
+                  createMode:
+                    description: 'CreateMode - Possible values include: ''CreateModeDefault'', ''CreateModePointInTimeRestore'', ''CreateModeGeoRestore'', ''CreateModeReplica'''
+                    enum:
+                    - Default
+                    - GeoRestore
+                    - PointInTimeRestore
+                    - Replica
+                    type: string
                   location:
                     description: Location specifies the location of this SQLServer.
                     type: string
@@ -94,6 +102,10 @@ spec:
                         description: MatchLabels ensures an object with matching labels is selected.
                         type: object
                     type: object
+                  restorePointInTime:
+                    description: RestorePointInTime - Restore point creation time (RFC3339 format), specifying the time to restore from.
+                    format: date-time
+                    type: string
                   sku:
                     description: SKU is the billing information related properties of the server.
                     properties:
@@ -118,6 +130,9 @@ spec:
                     - family
                     - tier
                     type: object
+                  sourceServerID:
+                    description: SourceServerID - The server to restore from when restoring or creating replicas
+                    type: string
                   sslEnforcement:
                     description: 'SSLEnforcement - Enable ssl enforcement or not when connect to server. Possible values include: ''Enabled'', ''Disabled'''
                     enum:

--- a/pkg/clients/database/util.go
+++ b/pkg/clients/database/util.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2019 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package database
+
+import (
+	"github.com/Azure/go-autorest/autorest/date"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/crossplane/provider-azure/apis/database/v1beta1"
+)
+
+// Get a pointer to a CreateMode
+func pointerFromCreateMode(createMode v1beta1.CreateMode) *v1beta1.CreateMode {
+	result := createMode
+	return &result
+}
+
+// Get a CreateMode from a pointer-to-CreateMode
+func pointerToCreateMode(mode *v1beta1.CreateMode) v1beta1.CreateMode {
+	if nil == mode {
+		return v1beta1.CreateModeDefault
+	}
+	return *mode
+}
+
+// Convert a possibly nil metav1.Time to a possibly nil date.Time
+func safeDate(time *metav1.Time) *date.Time {
+	if time == nil {
+		return nil
+	}
+	return &date.Time{Time: time.Time}
+}


### PR DESCRIPTION
Fixes: #209

The duplication in the creation of the Azure API object is undesirable
but I can't see any way around it short of serialising back to JSON and
up again via the Azure API JSON decode path, which seems more fragile
than the typed code path this provides.

Signed-off-by: Robert Collins <robert.collins@cognite.com>

### Description of your changes

Fixes #209 

I have:

- [X ] Read and followed Crossplane's [contribution process].
- [X ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I haven't yet testing this against a live Azure cluster - as with the fix for 210, I'd love some guidance on how to connect a dev build directly to a cluster - if someone can step me through it on slack I can write it up as a doc fix.