### PR TITLE
Always supply the Azure API with a SQL server create mode

### DIFF
--- a/pkg/clients/database/mysql.go
+++ b/pkg/clients/database/mysql.go
@@ -92,7 +92,7 @@ func toMySQLProperties(s v1beta1.SQLServerParameters, adminPassword string) mysq
 			MinimalTLSVersion:  mysql.MinimalTLSVersionEnum(s.MinimalTLSVersion),
 			Version:            mysql.ServerVersion(s.Version),
 			SslEnforcement:     mysql.SslEnforcementEnum(s.SSLEnforcement),
-			CreateMode:         mysql.CreateMode(createMode),
+			CreateMode:         mysql.CreateModePointInTimeRestore,
 			RestorePointInTime: safeDate(s.RestorePointInTime),
 			SourceServerID:     s.SourceServerID,
 			StorageProfile: &mysql.StorageProfile{
@@ -107,7 +107,7 @@ func toMySQLProperties(s v1beta1.SQLServerParameters, adminPassword string) mysq
 			MinimalTLSVersion: mysql.MinimalTLSVersionEnum(s.MinimalTLSVersion),
 			Version:           mysql.ServerVersion(s.Version),
 			SslEnforcement:    mysql.SslEnforcementEnum(s.SSLEnforcement),
-			CreateMode:        mysql.CreateMode(createMode),
+			CreateMode:        mysql.CreateModeGeoRestore,
 			SourceServerID:    s.SourceServerID,
 			StorageProfile: &mysql.StorageProfile{
 				BackupRetentionDays: azure.ToInt32PtrFromIntPtr(s.StorageProfile.BackupRetentionDays),
@@ -121,7 +121,7 @@ func toMySQLProperties(s v1beta1.SQLServerParameters, adminPassword string) mysq
 			MinimalTLSVersion: mysql.MinimalTLSVersionEnum(s.MinimalTLSVersion),
 			Version:           mysql.ServerVersion(s.Version),
 			SslEnforcement:    mysql.SslEnforcementEnum(s.SSLEnforcement),
-			CreateMode:        mysql.CreateMode(createMode),
+			CreateMode:        mysql.CreateModeReplica,
 			SourceServerID:    s.SourceServerID,
 			StorageProfile: &mysql.StorageProfile{
 				BackupRetentionDays: azure.ToInt32PtrFromIntPtr(s.StorageProfile.BackupRetentionDays),
@@ -139,7 +139,7 @@ func toMySQLProperties(s v1beta1.SQLServerParameters, adminPassword string) mysq
 			AdministratorLoginPassword: &adminPassword,
 			Version:                    mysql.ServerVersion(s.Version),
 			SslEnforcement:             mysql.SslEnforcementEnum(s.SSLEnforcement),
-			CreateMode:                 mysql.CreateMode(createMode),
+			CreateMode:                 mysql.CreateModeDefault,
 			StorageProfile: &mysql.StorageProfile{
 				BackupRetentionDays: azure.ToInt32PtrFromIntPtr(s.StorageProfile.BackupRetentionDays),
 				GeoRedundantBackup:  mysql.GeoRedundantBackup(azure.ToString(s.StorageProfile.GeoRedundantBackup)),

--- a/pkg/clients/database/mysql_test.go
+++ b/pkg/clients/database/mysql_test.go
@@ -63,15 +63,11 @@ func mySQLServerParameters(createMode *v1beta1.CreateMode) v1beta1.SQLServerPara
 	return fp
 }
 
-func mySQLServerPropertiesForDefaultCreate(withMode bool) mysql.BasicServerPropertiesForCreate {
+func mySQLServerPropertiesForDefaultCreate() mysql.BasicServerPropertiesForCreate {
 	adminPassword := "admin"
-	var mode mysql.CreateMode = mysql.CreateModeDefault
-	if !withMode {
-		mode = ""
-	}
 	return &mysql.ServerPropertiesForDefaultCreate{
 		AdministratorLoginPassword: &adminPassword,
-		CreateMode:                 mode,
+		CreateMode:                 mysql.CreateModeDefault,
 		StorageProfile:             &mysql.StorageProfile{},
 	}
 }
@@ -123,7 +119,7 @@ func TestToMySQLProperties(t *testing.T) {
 		{
 			name: "CreateModeDefault",
 			fp:   mySQLServerParameters(pointerFromCreateMode(v1beta1.CreateModeDefault)),
-			want: mySQLServerPropertiesForDefaultCreate(true),
+			want: mySQLServerPropertiesForDefaultCreate(),
 		},
 		{
 			name: "CreateModePointInTimeRestore",
@@ -143,12 +139,12 @@ func TestToMySQLProperties(t *testing.T) {
 		{
 			name: "ServerPropertiesForInvalidString",
 			fp:   mySQLServerParameters(pointerFromCreateMode("")),
-			want: mySQLServerPropertiesForDefaultCreate(false),
+			want: mySQLServerPropertiesForDefaultCreate(),
 		},
 		{
 			name: "ServerPropertiesForDefaultCreate",
 			fp:   mySQLServerParameters(nil),
-			want: mySQLServerPropertiesForDefaultCreate(false),
+			want: mySQLServerPropertiesForDefaultCreate(),
 		},
 	}
 

--- a/pkg/clients/database/postgresql.go
+++ b/pkg/clients/database/postgresql.go
@@ -84,7 +84,7 @@ func toPGSQLProperties(s v1beta1.SQLServerParameters, adminPassword string) post
 			MinimalTLSVersion:  postgresql.MinimalTLSVersionEnum(s.MinimalTLSVersion),
 			Version:            postgresql.ServerVersion(s.Version),
 			SslEnforcement:     postgresql.SslEnforcementEnum(s.SSLEnforcement),
-			CreateMode:         postgresql.CreateMode(createMode),
+			CreateMode:         postgresql.CreateModePointInTimeRestore,
 			RestorePointInTime: safeDate(s.RestorePointInTime),
 			SourceServerID:     s.SourceServerID,
 			StorageProfile: &postgresql.StorageProfile{
@@ -100,7 +100,7 @@ func toPGSQLProperties(s v1beta1.SQLServerParameters, adminPassword string) post
 			Version:           postgresql.ServerVersion(s.Version),
 			SslEnforcement:    postgresql.SslEnforcementEnum(s.SSLEnforcement),
 			SourceServerID:    s.SourceServerID,
-			CreateMode:        postgresql.CreateMode(createMode),
+			CreateMode:        postgresql.CreateModeGeoRestore,
 			StorageProfile: &postgresql.StorageProfile{
 				BackupRetentionDays: azure.ToInt32PtrFromIntPtr(s.StorageProfile.BackupRetentionDays),
 				GeoRedundantBackup:  postgresql.GeoRedundantBackup(azure.ToString(s.StorageProfile.GeoRedundantBackup)),
@@ -113,7 +113,7 @@ func toPGSQLProperties(s v1beta1.SQLServerParameters, adminPassword string) post
 			MinimalTLSVersion: postgresql.MinimalTLSVersionEnum(s.MinimalTLSVersion),
 			Version:           postgresql.ServerVersion(s.Version),
 			SslEnforcement:    postgresql.SslEnforcementEnum(s.SSLEnforcement),
-			CreateMode:        postgresql.CreateMode(createMode),
+			CreateMode:        postgresql.CreateModeReplica,
 			SourceServerID:    s.SourceServerID,
 			StorageProfile: &postgresql.StorageProfile{
 				BackupRetentionDays: azure.ToInt32PtrFromIntPtr(s.StorageProfile.BackupRetentionDays),
@@ -131,7 +131,7 @@ func toPGSQLProperties(s v1beta1.SQLServerParameters, adminPassword string) post
 			AdministratorLoginPassword: &adminPassword,
 			Version:                    postgresql.ServerVersion(s.Version),
 			SslEnforcement:             postgresql.SslEnforcementEnum(s.SSLEnforcement),
-			CreateMode:                 postgresql.CreateMode(createMode),
+			CreateMode:                 postgresql.CreateModeDefault,
 			StorageProfile: &postgresql.StorageProfile{
 				BackupRetentionDays: azure.ToInt32PtrFromIntPtr(s.StorageProfile.BackupRetentionDays),
 				GeoRedundantBackup:  postgresql.GeoRedundantBackup(azure.ToString(s.StorageProfile.GeoRedundantBackup)),

--- a/pkg/clients/database/postgresql_test.go
+++ b/pkg/clients/database/postgresql_test.go
@@ -52,15 +52,11 @@ func postgresqlServerParameters(createMode *v1beta1.CreateMode) v1beta1.SQLServe
 	return fp
 }
 
-func postgresqlServerPropertiesForDefaultCreate(withMode bool) postgresql.BasicServerPropertiesForCreate {
+func postgresqlServerPropertiesForDefaultCreate() postgresql.BasicServerPropertiesForCreate {
 	adminPassword := "admin"
-	var mode postgresql.CreateMode = postgresql.CreateModeDefault
-	if !withMode {
-		mode = ""
-	}
 	return &postgresql.ServerPropertiesForDefaultCreate{
 		AdministratorLoginPassword: &adminPassword,
-		CreateMode:                 mode,
+		CreateMode:                 postgresql.CreateModeDefault,
 		StorageProfile:             &postgresql.StorageProfile{},
 	}
 }
@@ -112,7 +108,7 @@ func TestTopostgresqlProperties(t *testing.T) {
 		{
 			name: "CreateModeDefault",
 			fp:   postgresqlServerParameters(pointerFromCreateMode(v1beta1.CreateModeDefault)),
-			want: postgresqlServerPropertiesForDefaultCreate(true),
+			want: postgresqlServerPropertiesForDefaultCreate(),
 		},
 		{
 			name: "CreateModePointInTimeRestore",
@@ -132,12 +128,12 @@ func TestTopostgresqlProperties(t *testing.T) {
 		{
 			name: "ServerPropertiesForInvalidString",
 			fp:   postgresqlServerParameters(pointerFromCreateMode("")),
-			want: postgresqlServerPropertiesForDefaultCreate(false),
+			want: postgresqlServerPropertiesForDefaultCreate(),
 		},
 		{
 			name: "ServerPropertiesForDefaultCreate",
 			fp:   postgresqlServerParameters(nil),
-			want: postgresqlServerPropertiesForDefaultCreate(false),
+			want: postgresqlServerPropertiesForDefaultCreate(),
 		},
 	}
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
https://github.com/crossplane/provider-azure/pull/214 managed to sneak some broken unit tests into master (I think due to some quirk of the detect-noop job). There were some cases in which our tests expected us to send an empty-string CreateMode to the Azure API whereas in practice we were sending `Default`. I believe we always want to send one of the valid create modes (i.e. we should never try to send the empty string).

CC @rbtcollins 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
