### PR TITLE
Remove Queue and Table related encryption operations

### DIFF
--- a/apis/storage/v1alpha3/account.go
+++ b/apis/storage/v1alpha3/account.go
@@ -68,12 +68,6 @@ type EnabledEncryptionServices struct {
 
 	// File - The encryption function of the file storage service.
 	File bool `json:"file,omitempty"`
-
-	// Table - The encryption function of the table storage service.
-	Table bool `json:"table,omitempty"`
-
-	// Queue - The encryption function of the queue storage service.
-	Queue bool `json:"queue,omitempty"`
 }
 
 // newEnabledEncryptionServices from the storage equivalent
@@ -86,20 +80,16 @@ func newEnabledEncryptionServices(s *storage.EncryptionServices) *EnabledEncrypt
 		return s != nil && s.Enabled != nil && *s.Enabled
 	}
 	return &EnabledEncryptionServices{
-		Blob:  b(s.Blob),
-		File:  b(s.File),
-		Table: b(s.Table),
-		Queue: b(s.Queue),
+		Blob: b(s.Blob),
+		File: b(s.File),
 	}
 }
 
 // toStorageEncryptedServices format
 func toStorageEncryptedServices(s *EnabledEncryptionServices) *storage.EncryptionServices {
 	return &storage.EncryptionServices{
-		Blob:  &storage.EncryptionService{Enabled: to.BoolPtr(s.Blob)},
-		File:  &storage.EncryptionService{Enabled: to.BoolPtr(s.File)},
-		Table: &storage.EncryptionService{Enabled: to.BoolPtr(s.Table)},
-		Queue: &storage.EncryptionService{Enabled: to.BoolPtr(s.Queue)},
+		Blob: &storage.EncryptionService{Enabled: to.BoolPtr(s.Blob)},
+		File: &storage.EncryptionService{Enabled: to.BoolPtr(s.File)},
 	}
 }
 

--- a/apis/storage/v1alpha3/account_test.go
+++ b/apis/storage/v1alpha3/account_test.go
@@ -95,16 +95,12 @@ func Test_newEnabledEncryptionServices(t *testing.T) {
 		{
 			name: "test",
 			args: &storage.EncryptionServices{
-				File:  &storage.EncryptionService{Enabled: to.BoolPtr(true), LastEnabledTime: &date.Time{Time: now}},
-				Table: &storage.EncryptionService{Enabled: to.BoolPtr(true), LastEnabledTime: nil},
-				Queue: &storage.EncryptionService{Enabled: to.BoolPtr(false), LastEnabledTime: nil},
-				Blob:  nil,
+				File: &storage.EncryptionService{Enabled: to.BoolPtr(true), LastEnabledTime: &date.Time{Time: now}},
+				Blob: nil,
 			},
 			want: &EnabledEncryptionServices{
-				File:  true,
-				Table: true,
-				Queue: false,
-				Blob:  false,
+				File: true,
+				Blob: false,
 			},
 		},
 	}
@@ -127,16 +123,12 @@ func Test_toStorageEncryptedServices(t *testing.T) {
 		{
 			name: "test",
 			args: &EnabledEncryptionServices{
-				Blob:  true,
-				File:  false,
-				Table: true,
-				Queue: false,
+				Blob: true,
+				File: false,
 			},
 			want: &storage.EncryptionServices{
-				Blob:  &storage.EncryptionService{Enabled: to.BoolPtr(true)},
-				File:  &storage.EncryptionService{Enabled: to.BoolPtr(false)},
-				Table: &storage.EncryptionService{Enabled: to.BoolPtr(true)},
-				Queue: &storage.EncryptionService{Enabled: to.BoolPtr(false)},
+				Blob: &storage.EncryptionService{Enabled: to.BoolPtr(true)},
+				File: &storage.EncryptionService{Enabled: to.BoolPtr(false)},
 			},
 		},
 	}
@@ -192,10 +184,8 @@ func Test_toStorageEncryption(t *testing.T) {
 			},
 			want: &storage.Encryption{
 				Services: &storage.EncryptionServices{
-					Blob:  &storage.EncryptionService{Enabled: to.BoolPtr(false)},
-					File:  &storage.EncryptionService{Enabled: to.BoolPtr(false)},
-					Table: &storage.EncryptionService{Enabled: to.BoolPtr(false)},
-					Queue: &storage.EncryptionService{Enabled: to.BoolPtr(false)},
+					Blob: &storage.EncryptionService{Enabled: to.BoolPtr(false)},
+					File: &storage.EncryptionService{Enabled: to.BoolPtr(false)},
 				},
 				KeySource: storage.MicrosoftKeyvault,
 				KeyVaultProperties: &storage.KeyVaultProperties{

--- a/package/crds/storage.azure.crossplane.io_accounts.yaml
+++ b/package/crds/storage.azure.crossplane.io_accounts.yaml
@@ -146,12 +146,6 @@ spec:
                               file:
                                 description: File - The encryption function of the file storage service.
                                 type: boolean
-                              queue:
-                                description: Queue - The encryption function of the queue storage service.
-                                type: boolean
-                              table:
-                                description: Table - The encryption function of the table storage service.
-                                type: boolean
                             type: object
                         type: object
                       networkAcls:


### PR DESCRIPTION
Signed-off-by: craigbryson <37695591+craigbryson@users.noreply.github.com>

### Description of your changes

Fixes #232 

Removes options for table and queue encryption since these cannot be modified. Accounts now reconcile successfully.

There are some potentially breaking changes to CRDs (removal) not sure how best to handle these?

I have:

- [ X] Read and followed Crossplane's [contribution process].
- [ X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested locally provisioning a storage account as per the issue - account now reconciles successfully. No failed API operations are shown in the activity log

[contribution process]: https://git.io/fj2m9
