### PR TITLE
sql: late init enum fields

### DIFF
--- a/pkg/clients/database/mysql.go
+++ b/pkg/clients/database/mysql.go
@@ -315,6 +315,12 @@ func LateInitializeMySQL(p *azuredbv1beta1.SQLServerParameters, in mysql.Server)
 		p.StorageProfile.GeoRedundantBackup = azure.LateInitializeStringPtrFromVal(p.StorageProfile.GeoRedundantBackup, string(in.StorageProfile.GeoRedundantBackup))
 		p.StorageProfile.StorageAutogrow = azure.LateInitializeStringPtrFromVal(p.StorageProfile.StorageAutogrow, string(in.StorageProfile.StorageAutogrow))
 	}
+	if p.MinimalTLSVersion == "" {
+		p.MinimalTLSVersion = string(in.MinimalTLSVersion)
+	}
+	if p.SSLEnforcement == "" {
+		p.SSLEnforcement = string(in.SslEnforcement)
+	}
 }
 
 // IsMySQLUpToDate is used to report whether given mysql.Server is in

--- a/pkg/clients/database/postgresql.go
+++ b/pkg/clients/database/postgresql.go
@@ -307,6 +307,12 @@ func LateInitializePostgreSQL(p *azuredbv1beta1.SQLServerParameters, in postgres
 		p.StorageProfile.GeoRedundantBackup = azure.LateInitializeStringPtrFromVal(p.StorageProfile.GeoRedundantBackup, string(in.StorageProfile.GeoRedundantBackup))
 		p.StorageProfile.StorageAutogrow = azure.LateInitializeStringPtrFromVal(p.StorageProfile.StorageAutogrow, string(in.StorageProfile.StorageAutogrow))
 	}
+	if p.MinimalTLSVersion == "" {
+		p.MinimalTLSVersion = string(in.MinimalTLSVersion)
+	}
+	if p.SSLEnforcement == "" {
+		p.SSLEnforcement = string(in.SslEnforcement)
+	}
 }
 
 // IsPostgreSQLUpToDate is used to report whether given postgresql.Server is in


### PR DESCRIPTION
### Description of your changes

It reports difference in `IsUpToDate` because the local value is always empty while the remote one always has a value since it's an enum.

Fixes https://github.com/crossplane/provider-azure/issues/237

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Manual test not necessary.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
