### PR TITLE
Mark status.endpoint as optional in AKSCluster

### DIFF
--- a/apis/compute/v1alpha3/types.go
+++ b/apis/compute/v1alpha3/types.go
@@ -101,7 +101,7 @@ type AKSClusterStatus struct {
 	ProviderID string `json:"providerID,omitempty"`
 
 	// Endpoint is the endpoint where the cluster can be reached
-	Endpoint string `json:"endpoint"`
+	Endpoint string `json:"endpoint,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/package/crds/compute.azure.crossplane.io_aksclusters.yaml
+++ b/package/crds/compute.azure.crossplane.io_aksclusters.yaml
@@ -199,8 +199,6 @@ spec:
               state:
                 description: State is the current state of the cluster.
                 type: string
-            required:
-            - endpoint
             type: object
         required:
         - spec


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
While running crossplane conformance tests, I observed following failure:

```
=== RUN   TestPackage/DeploysConformantCRDs/AKSCluster
    provider_test.go:436: version "v1alpha3" OpenAPI schema: -want, +got:
          &v1.JSONSchemaProps{
            ... // 1 ignored and 25 identical fields
            AnyOf: nil,
            Not:   nil,
            Properties: map[string]v1.JSONSchemaProps{
                ... // 2 identical entries
                "metadata": {Type: "object"},
+ go-junit-report
                "spec":     {Type: "object", Properties: {"deletionPolicy": {Type: "string", Enum: {{Raw: {0x22, 0x4f, 0x72, 0x70, ...}}, {Raw: {0x22, 0x44, 0x65, 0x6c, ...}}}}, "providerConfigRef": {Type: "object", Required: {"name"}, Properties: {"name": {Type: "string"}}}, "writeConnectionSecretToRef": {Type: "object", Required: {"name", "namespace"}, Properties: {"name": {Type: "string"}, "namespace": {Type: "string"}}}, ...}},
                "status": {
                    ... // 1 ignored and 19 identical fields
                    MaxProperties: nil,
                    MinProperties: nil,
        -           Required:      nil,
        +           Required:      []string{"endpoint"},
                    Items:         nil,
                    AllOf:         nil,
                    ... // 18 identical fields
                },
            },
            AdditionalProperties: nil,
            PatternProperties:    nil,
            ... // 12 identical fields
          }
```

It does not make sense to have a field as "required" in the status of a custom resource since that is not set by the user rather managed by the provider controller. 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

- Deploy provider-azure
- Create an AKSCluster resource
- Verify it reports ready with valid status
