### PR TITLE
Fix Print Columns for Subnet

### DIFF
--- a/apis/network/v1alpha3/types.go
+++ b/apis/network/v1alpha3/types.go
@@ -204,8 +204,9 @@ type SubnetStatus struct {
 // +kubebuilder:object:root=true
 
 // A Subnet is a managed resource that represents an Azure Subnet.
+// +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
+// +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".status.state"
-// +kubebuilder:printcolumn:name="LOCATION",type="string",JSONPath=".spec.location"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,azure}

--- a/package/crds/network.azure.crossplane.io_subnets.yaml
+++ b/package/crds/network.azure.crossplane.io_subnets.yaml
@@ -19,11 +19,14 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: READY
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Synced')].status
+      name: SYNCED
+      type: string
     - jsonPath: .status.state
       name: STATE
-      type: string
-    - jsonPath: .spec.location
-      name: LOCATION
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: AGE


### PR DESCRIPTION
Signed-off-by: Hasan Turken <turkenh@gmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Subnet does not have a `spec.location` and ready/synced not available in get output.

This PR changes from:

```
NAME               STATE      LOCATION   AGE
conformancetest1   Updating              6m41s
```

To:

```
NAME               READY   SYNCED   STATE      AGE
conformancetest1   False   True     Updating   7m22s
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Create a subnet and run kubectl get.

[contribution process]: https://git.io/fj2m9
