### PR TITLE
Remove FieldRequired for EnableVMProtection VNET property

### DIFF
--- a/pkg/clients/network/network.go
+++ b/pkg/clients/network/network.go
@@ -32,7 +32,7 @@ func NewVirtualNetworkParameters(v *v1alpha3.VirtualNetwork) networkmgmt.Virtual
 		Tags:     azure.ToStringPtrMap(v.Spec.Tags),
 		VirtualNetworkPropertiesFormat: &networkmgmt.VirtualNetworkPropertiesFormat{
 			EnableDdosProtection: azure.ToBoolPtr(v.Spec.VirtualNetworkPropertiesFormat.EnableDDOSProtection, azure.FieldRequired),
-			EnableVMProtection:   azure.ToBoolPtr(v.Spec.VirtualNetworkPropertiesFormat.EnableVMProtection, azure.FieldRequired),
+			EnableVMProtection:   azure.ToBoolPtr(v.Spec.VirtualNetworkPropertiesFormat.EnableVMProtection),
 			AddressSpace: &networkmgmt.AddressSpace{
 				AddressPrefixes: &v.Spec.VirtualNetworkPropertiesFormat.AddressSpace.AddressPrefixes,
 			},

--- a/pkg/clients/network/network_test.go
+++ b/pkg/clients/network/network_test.go
@@ -99,7 +99,7 @@ func TestNewVirtualNetworkParameters(t *testing.T) {
 				Tags:     azure.ToStringPtrMap(nil),
 				VirtualNetworkPropertiesFormat: &networkmgmt.VirtualNetworkPropertiesFormat{
 					EnableDdosProtection: to.BoolPtr(enableDDOSProtection),
-					EnableVMProtection:   to.BoolPtr(false),
+					EnableVMProtection:   nil,
 					AddressSpace: &networkmgmt.AddressSpace{
 						AddressPrefixes: &addressPrefixes,
 					},


### PR DESCRIPTION
### Description of your changes

When setting this property to False in the Crossplane VirtualNetwork CR,
the controller finds itself constantly reconciling actual and desired
state. This leads to a lot of instability when trying to create
resources in that VNET, as there is never any convergence.

Adding a few log messages in the provider, I observed that there was
always a mismatch between the EnableVMProtection property for the
desired object (pointer to a boolean value set to false) and the one
for the actual object obtained from the Azure SDK (which is nil).

So it seems that using FieldRequired for EnableVMProtection may not be
accurate, at least not with the version of the SDK currently used by
Crossplane.

Signed-off-by: Antonin Bas <abas@vmware.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Created Vnets with EnableVMProtection set to false and looked at reconciliation logs.

[contribution process]: https://git.io/fj2m9
