### PR TITLE
Add global poll interval flag

### DIFF
--- a/pkg/controller/azure.go
+++ b/pkg/controller/azure.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controller
 
 import (
+	"time"
+
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -40,9 +42,8 @@ import (
 )
 
 // Setup Azure controllers.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
-	for _, setup := range []func(ctrl.Manager, logging.Logger, workqueue.RateLimiter) error{
-		config.Setup,
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
+	for _, setup := range []func(ctrl.Manager, logging.Logger, workqueue.RateLimiter, time.Duration) error{
 		cache.SetupRedis,
 		compute.SetupAKSCluster,
 		mysqlserver.Setup,
@@ -58,9 +59,9 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 		account.Setup,
 		container.Setup,
 	} {
-		if err := setup(mgr, l, rl); err != nil {
+		if err := setup(mgr, l, rl, poll); err != nil {
 			return err
 		}
 	}
-	return nil
+	return config.Setup(mgr, l, rl)
 }

--- a/pkg/controller/cache/redis.go
+++ b/pkg/controller/cache/redis.go
@@ -19,6 +19,7 @@ package cache
 import (
 	"context"
 	"strconv"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/redis/mgmt/redis"
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/redis/mgmt/redis/redisapi"
@@ -54,7 +55,7 @@ const (
 )
 
 // SetupRedis adds a controller that reconciles Redis resources.
-func SetupRedis(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupRedis(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1beta1.RedisGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -67,6 +68,7 @@ func SetupRedis(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) er
 			resource.ManagedKind(v1beta1.RedisGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/compute/managed.go
+++ b/pkg/controller/compute/managed.go
@@ -18,6 +18,7 @@ package compute
 
 import (
 	"context"
+	"time"
 
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/pkg/errors"
@@ -52,7 +53,7 @@ const (
 )
 
 // SetupAKSCluster adds a controller that reconciles AKSClusters.
-func SetupAKSCluster(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupAKSCluster(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha3.AKSClusterGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -65,6 +66,7 @@ func SetupAKSCluster(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimite
 			resource.ManagedKind(v1alpha3.AKSClusterGroupVersionKind),
 			managed.WithExternalConnecter(&connecter{client: mgr.GetClient()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/database/cosmosdb/managed.go
+++ b/pkg/controller/database/cosmosdb/managed.go
@@ -19,6 +19,7 @@ package cosmosdb
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2015-04-08/documentdb"
 	"github.com/pkg/errors"
@@ -49,7 +50,7 @@ const (
 )
 
 // Setup adds a controller that reconciles NoSQLAccount.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha3.CosmosDBAccountGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -63,6 +64,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 			managed.WithConnectionPublishers(),
 			managed.WithExternalConnecter(&connecter{kube: mgr.GetClient()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/database/mysqlserver/managed.go
+++ b/pkg/controller/database/mysqlserver/managed.go
@@ -19,6 +19,7 @@ package mysqlserver
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/mysql/mgmt/2017-12-01/mysql"
 	"k8s.io/client-go/util/workqueue"
@@ -55,7 +56,7 @@ const (
 )
 
 // Setup adds a controller that reconciles MySQLServers.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1beta1.MySQLServerGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -68,6 +69,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 			resource.ManagedKind(v1beta1.MySQLServerGroupVersionKind),
 			managed.WithExternalConnecter(&connecter{client: mgr.GetClient()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/database/mysqlserverfirewallrule/managed.go
+++ b/pkg/controller/database/mysqlserverfirewallrule/managed.go
@@ -18,6 +18,7 @@ package mysqlserverfirewallrule
 
 import (
 	"context"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/mysql/mgmt/2017-12-01/mysql"
 	"github.com/Azure/azure-sdk-for-go/services/mysql/mgmt/2017-12-01/mysql/mysqlapi"
@@ -50,7 +51,7 @@ const (
 )
 
 // Setup adds a controller that reconciles MySQLServerFirewallRules.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha3.MySQLServerFirewallRuleGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -64,6 +65,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 			managed.WithConnectionPublishers(),
 			managed.WithExternalConnecter(&connecter{client: mgr.GetClient()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/database/mysqlservervirtualnetworkrule/managed.go
+++ b/pkg/controller/database/mysqlservervirtualnetworkrule/managed.go
@@ -18,6 +18,7 @@ package mysqlservervirtualnetworkrule
 
 import (
 	"context"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/mysql/mgmt/2017-12-01/mysql"
 	"github.com/Azure/azure-sdk-for-go/services/mysql/mgmt/2017-12-01/mysql/mysqlapi"
@@ -50,7 +51,7 @@ const (
 )
 
 // Setup adds a controller that reconciles MySQLServerVirtualNetworkRules.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha3.MySQLServerVirtualNetworkRuleGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -64,6 +65,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 			managed.WithConnectionPublishers(),
 			managed.WithExternalConnecter(&connecter{client: mgr.GetClient()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/database/postgresqlserver/managed.go
+++ b/pkg/controller/database/postgresqlserver/managed.go
@@ -19,6 +19,7 @@ package postgresqlserver
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/postgresql/mgmt/2017-12-01/postgresql"
 	v1 "k8s.io/api/core/v1"
@@ -58,7 +59,7 @@ const (
 )
 
 // Setup adds a controller that reconciles PostgreSQLInstances.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1beta1.PostgreSQLServerGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -71,6 +72,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 			resource.ManagedKind(v1beta1.PostgreSQLServerGroupVersionKind),
 			managed.WithExternalConnecter(&connecter{client: mgr.GetClient()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/database/postgresqlserverfirewallrule/managed.go
+++ b/pkg/controller/database/postgresqlserverfirewallrule/managed.go
@@ -18,6 +18,7 @@ package postgresqlserverfirewallrule
 
 import (
 	"context"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/postgresql/mgmt/2017-12-01/postgresql"
 	"github.com/Azure/azure-sdk-for-go/services/postgresql/mgmt/2017-12-01/postgresql/postgresqlapi"
@@ -50,7 +51,7 @@ const (
 )
 
 // Setup adds a controller that reconciles PostgreSQLServerFirewallRules.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha3.PostgreSQLServerFirewallRuleGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -64,6 +65,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 			managed.WithConnectionPublishers(),
 			managed.WithExternalConnecter(&connecter{client: mgr.GetClient()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/database/postgresqlservervirtualnetworkrule/managed.go
+++ b/pkg/controller/database/postgresqlservervirtualnetworkrule/managed.go
@@ -18,6 +18,7 @@ package postgresqlservervirtualnetworkrule
 
 import (
 	"context"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/postgresql/mgmt/2017-12-01/postgresql/postgresqlapi"
 	"k8s.io/client-go/util/workqueue"
@@ -52,7 +53,7 @@ const (
 )
 
 // Setup adds a controller that reconciles PostgreSQLServerVirtualNetworkRules.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha3.PostgreSQLServerVirtualNetworkRuleGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -66,6 +67,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 			managed.WithConnectionPublishers(),
 			managed.WithExternalConnecter(&connecter{client: mgr.GetClient()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/network/subnet/managed.go
+++ b/pkg/controller/network/subnet/managed.go
@@ -18,6 +18,7 @@ package subnet
 
 import (
 	"context"
+	"time"
 
 	azurenetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-06-01/network"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-06-01/network/networkapi"
@@ -50,7 +51,7 @@ const (
 )
 
 // Setup adds a controller that reconciles Subnets.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha3.SubnetGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -64,6 +65,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 			managed.WithConnectionPublishers(),
 			managed.WithExternalConnecter(&connecter{client: mgr.GetClient()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/network/virtualnetwork/managed.go
+++ b/pkg/controller/network/virtualnetwork/managed.go
@@ -18,6 +18,7 @@ package virtualnetwork
 
 import (
 	"context"
+	"time"
 
 	azurenetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-06-01/network"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-06-01/network/networkapi"
@@ -50,7 +51,7 @@ const (
 )
 
 // Setup adds a controller that reconciles VirtualNetworks.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha3.VirtualNetworkGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -64,6 +65,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 			managed.WithConnectionPublishers(),
 			managed.WithExternalConnecter(&connecter{client: mgr.GetClient()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/resourcegroup/resourcegroup.go
+++ b/pkg/controller/resourcegroup/resourcegroup.go
@@ -19,6 +19,7 @@ package resourcegroup
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
 	"k8s.io/client-go/util/workqueue"
@@ -53,7 +54,7 @@ const (
 )
 
 // Setup adds a controller that reconciles ResourceGroups.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha3.ResourceGroupGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -66,6 +67,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 			resource.ManagedKind(v1alpha3.ResourceGroupGroupVersionKind),
 			managed.WithConnectionPublishers(),
 			managed.WithExternalConnecter(&connecter{kube: mgr.GetClient()}),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Adds a `--poll-interval` flag to provider, which is passed to all controllers to set their polling interval in the reconciliation happy path.

*Note to reviewers: these changes are almost entirely find and replace.*

xref https://github.com/crossplane/crossplane-runtime/issues/253
Fixes #282 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

See https://github.com/crossplane/provider-aws/pull/741 for testing steps.

[contribution process]: https://git.io/fj2m9
