### PR TITLE
Read PostgreSQL admin password from connection secret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.14'
+  GO_VERSION: '1.16'
   GOLANGCI_VERSION: 'v1.31'
   DOCKER_BUILDX_VERSION: 'v0.4.2'
 

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ PROJECT_NAME := provider-azure
 PROJECT_REPO := github.com/crossplane/$(PROJECT_NAME)
 
 PLATFORMS ?= linux_amd64 linux_arm64
+
+# kind-related versions
+KIND_VERSION ?= v0.11.1
+KIND_NODE_IMAGE_TAG ?= v1.19.11
 # -include will silently skip missing files, which allows us
 # to load those files with a target in the Makefile. If only
 # "include" was used, the make command would fail and refuse
@@ -92,7 +96,7 @@ e2e.run: test-integration
 # Run integration tests.
 test-integration: $(KIND) $(KUBECTL) $(HELM3)
 	@$(INFO) running integration tests using kind $(KIND_VERSION)
-	@$(ROOT_DIR)/cluster/local/integration_tests.sh || $(FAIL)
+	@KIND_NODE_IMAGE_TAG=${KIND_NODE_IMAGE_TAG} KIND_VERSION=${KIND_VERSION} $(ROOT_DIR)/cluster/local/integration_tests.sh || $(FAIL)
 	@$(OK) integration tests passed
 
 # Update the submodules, such as the common build scripts.
@@ -115,6 +119,8 @@ manifests:
 # using unit tests.
 KUBEBUILDER_VERSION ?= 1.0.8
 KUBEBUILDER := $(TOOLS_HOST_DIR)/kubebuilder-$(KUBEBUILDER_VERSION)
+KUBEBUILDER_OS ?= $(GOHOSTOS)
+KUBEBUILDER_ARCH ?= $(GOHOSTARCH)
 TEST_ASSET_KUBE_APISERVER := $(KUBEBUILDER)/kube-apiserver
 TEST_ASSET_ETCD := $(KUBEBUILDER)/etcd
 export TEST_ASSET_KUBE_APISERVER TEST_ASSET_ETCD
@@ -150,7 +156,7 @@ help-special: crossplane.help
 $(KUBEBUILDER):
 	@$(INFO) installing kubebuilder $(KUBEBUILDER_VERSION)
 	@mkdir -p $(TOOLS_HOST_DIR)/tmp || $(FAIL)
-	@curl -fsSL https://github.com/kubernetes-sigs/kubebuilder/releases/download/v$(KUBEBUILDER_VERSION)/kubebuilder_$(KUBEBUILDER_VERSION)_$(GOHOSTOS)_$(GOHOSTARCH).tar.gz | tar -xz -C $(TOOLS_HOST_DIR)/tmp  || $(FAIL)
-	@mv $(TOOLS_HOST_DIR)/tmp/kubebuilder_$(KUBEBUILDER_VERSION)_$(GOHOSTOS)_$(GOHOSTARCH)/bin $(KUBEBUILDER) || $(FAIL)
+	@curl -fsSL https://github.com/kubernetes-sigs/kubebuilder/releases/download/v$(KUBEBUILDER_VERSION)/kubebuilder_$(KUBEBUILDER_VERSION)_$(KUBEBUILDER_OS)_$(KUBEBUILDER_ARCH).tar.gz | tar -xz -C $(TOOLS_HOST_DIR)/tmp  || $(FAIL)
+	@mv $(TOOLS_HOST_DIR)/tmp/kubebuilder_$(KUBEBUILDER_VERSION)_$(KUBEBUILDER_OS)_$(KUBEBUILDER_ARCH)/bin $(KUBEBUILDER) || $(FAIL)
 	@rm -fr $(TOOLS_HOST_DIR)/tmp
 	@$(OK) installing kubebuilder $(KUBEBUILDER_VERSION)

--- a/cluster/local/integration_tests.sh
+++ b/cluster/local/integration_tests.sh
@@ -71,7 +71,8 @@ echo "created cache dir at ${CACHE_PATH}"
 docker save "${BUILD_IMAGE}" -o "${CACHE_PATH}/${PACKAGE_NAME}.xpkg" && chmod 644 "${CACHE_PATH}/${PACKAGE_NAME}.xpkg"
 
 # create kind cluster with extra mounts
-echo_step "creating k8s cluster using kind"
+KIND_NODE_IMAGE="kindest/node:${KIND_NODE_IMAGE_TAG}"
+echo_step "creating k8s cluster using kind ${KIND_VERSION} and node image ${KIND_NODE_IMAGE}"
 KIND_CONFIG="$( cat <<EOF
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
@@ -82,7 +83,7 @@ nodes:
     containerPath: /cache
 EOF
 )"
-echo "${KIND_CONFIG}" | "${KIND}" create cluster --name="${K8S_CLUSTER}" --wait=5m --config=-
+echo "${KIND_CONFIG}" | "${KIND}" create cluster --name="${K8S_CLUSTER}" --wait=5m --image="${KIND_NODE_IMAGE}" --config=-
 
 # tag controller image and load it into kind cluster
 docker tag "${CONTROLLER_IMAGE}" "${PACKAGE_CONTROLLER_IMAGE}"

--- a/pkg/controller/database/postgresqlserver/managed.go
+++ b/pkg/controller/database/postgresqlserver/managed.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/services/postgresql/mgmt/2017-12-01/postgresql"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
@@ -52,6 +54,7 @@ const (
 	errGetPostgreSQLServer    = "cannot get PostgreSQLServer"
 	errDeletePostgreSQLServer = "cannot delete PostgreSQLServer"
 	errFetchLastOperation     = "cannot fetch last operation"
+	errGetConnSecret          = "cannot get connection secret"
 )
 
 // Setup adds a controller that reconciles PostgreSQLInstances.
@@ -146,6 +149,22 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	return o, nil
 }
 
+func (e *external) getPassword(ctx context.Context, cr *v1beta1.PostgreSQLServer) (string, error) {
+	if cr == nil || cr.Spec.WriteConnectionSecretToReference.Name == "" || cr.Spec.WriteConnectionSecretToReference.Namespace == "" {
+		return "", nil
+	}
+
+	s := &v1.Secret{}
+	if err := e.kube.Get(ctx, types.NamespacedName{
+		Namespace: cr.Spec.WriteConnectionSecretToReference.Namespace,
+		Name:      cr.Spec.WriteConnectionSecretToReference.Name,
+	}, s); err != nil {
+		return "", errors.Wrap(err, errGetConnSecret)
+	}
+
+	return string(s.Data[xpv1.ResourceCredentialsSecretPasswordKey]), nil
+}
+
 func (e *external) Create(ctx context.Context, mg resource.Managed) (managed.ExternalCreation, error) {
 	cr, ok := mg.(*v1beta1.PostgreSQLServer)
 	if !ok {
@@ -154,7 +173,13 @@ func (e *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 
 	cr.SetConditions(xpv1.Creating())
 
-	pw, err := e.newPasswordFn()
+	pw, err := e.getPassword(ctx, cr)
+	if err != nil {
+		return managed.ExternalCreation{}, err
+	}
+	if pw == "" {
+		pw, err = e.newPasswordFn()
+	}
 	if err != nil {
 		return managed.ExternalCreation{}, errors.Wrap(err, errGenPassword)
 	}

--- a/pkg/controller/database/postgresqlserver/managed.go
+++ b/pkg/controller/database/postgresqlserver/managed.go
@@ -150,7 +150,8 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 }
 
 func (e *external) getPassword(ctx context.Context, cr *v1beta1.PostgreSQLServer) (string, error) {
-	if cr == nil || cr.Spec.WriteConnectionSecretToReference.Name == "" || cr.Spec.WriteConnectionSecretToReference.Namespace == "" {
+	if cr.Spec.WriteConnectionSecretToReference == nil ||
+		cr.Spec.WriteConnectionSecretToReference.Name == "" || cr.Spec.WriteConnectionSecretToReference.Namespace == "" {
 		return "", nil
 	}
 
@@ -179,9 +180,9 @@ func (e *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 	}
 	if pw == "" {
 		pw, err = e.newPasswordFn()
-	}
-	if err != nil {
-		return managed.ExternalCreation{}, errors.Wrap(err, errGenPassword)
+		if err != nil {
+			return managed.ExternalCreation{}, errors.Wrap(err, errGenPassword)
+		}
 	}
 	if err := e.client.CreateServer(ctx, cr, pw); err != nil {
 		return managed.ExternalCreation{}, errors.Wrap(err, errCreatePostgreSQLServer)


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR proposes a fix for the wrong password in the generated connection secret issue discussed in #230. The proposed behavior is backwards-compatible and in case multiple `Creates` are called and if a connection secret is defined, we make sure that the password initially used to make the Azure PostgreSQLServer create call is reused, effectively preventing multiple erroneous password generations and the issue described in #230. 

Fixes #230 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
I have written a test script that does the following in a loop:
1. Apply the claim defined below to provision a PostgreSQLServer
2. Waits until the PostgreSQLServer MR becomes ready
3. Invokes `az postgres server firewall-rule create` against this newly provisioned instance to allow connections from my workstation
4. Invokes `psql` using the credentials and the connection info stored in the connection secret.
5. Deletes the claim
6. Waits until PostgreSQLServer MR is actually removed

With the proposed fix, issue #230 has *not* been observed in 10 iterations of the above loop. However, running the experiment with the head of the master branch, out of 10 trials, 8 were successful and 2 have failed with the issue reported in #230 (`psql: error: FATAL:  password authentication failed for user "myadmin"`).

Manifests used for the experiments are as follows. These are some stripped down versions of the manifests given [here](https://github.com/crossplane/crossplane/discussions/2192) by @haraldatbmw:
```
---
apiVersion: foo.bar/v1alpha1
kind: PostgreSQLInstance
metadata:
  namespace: default
  name: example
spec:
  parameters:
    location: westeurope
    storageGB: 5
    version: "11"
    virtualNetworkSubnetId: /subscriptions/xxx/resourceGroups/xxx/providers/Microsoft.Network/virtualNetworks/xxx/subnets/xxx
    dbName: example-db
  compositionSelector:
    matchLabels:
      provider: azure
  writeConnectionSecretToRef:
    name: example-db-connection

---
apiVersion: apiextensions.crossplane.io/v1
kind: Composition
metadata:
  name: compositepostgresqlinstances.azure.foo.bar
  labels:
    provider: azure
spec:
  writeConnectionSecretsToNamespace: crossplane-system
  compositeTypeRef:
    apiVersion: foo.bar/v1alpha1
    kind: CompositePostgreSQLInstance
  patchSets:
  - name: Metadata
    patches:
    - fromFieldPath: metadata.labels
    - fromFieldPath: metadata.annotations[crossplane.io/external-name]
  resources:
  # resource-group where the db-server lives in
  - name: resourcegroup
    base:
      apiVersion: azure.crossplane.io/v1alpha3
      kind: ResourceGroup
      spec: {}
    patches:
    - type: PatchSet
      patchSetName: Metadata
    - fromFieldPath: "spec.parameters.location"
      toFieldPath: "spec.location"
  # db-server
  - name: postgresqlserver
    base:
      apiVersion: database.azure.crossplane.io/v1beta1
      kind: PostgreSQLServer
      spec:
        forProvider:
          createMode: Default
          administratorLogin: myadmin
          resourceGroupNameSelector:
            matchControllerRef: true
          minimalTlsVersion: TLS1_2
          sslEnforcement: Enabled
          sku:
            tier: GeneralPurpose
            capacity: 2
            family: Gen5  
          storageProfile:
            backupRetentionDays: 35
            geoRedundantBackup: Disabled
            storageAutogrow: Disabled
        writeConnectionSecretToRef:
          namespace: crossplane-system
        providerConfigRef:
          name: default
    patches:
    - type: PatchSet
      patchSetName: Metadata
    - fromFieldPath: "metadata.uid"
      toFieldPath: "spec.writeConnectionSecretToRef.name"
      transforms:
      - type: string
        string:
          fmt: "postgresqlserver-admin-%s"
    - fromFieldPath: "spec.parameters.version"
      toFieldPath: "spec.forProvider.version"
    - fromFieldPath: "spec.parameters.location"
      toFieldPath: "spec.forProvider.location"
    - fromFieldPath: "spec.parameters.storageGB"
      toFieldPath: "spec.forProvider.storageProfile.storageMB"
      transforms:
        - type: math
          math:
            multiply: 1024
  # db-server vnet-rule for subnet where AKS lives in
  - name: vnetrule
    base:
      apiVersion: database.azure.crossplane.io/v1alpha3
      kind: PostgreSQLServerVirtualNetworkRule
      spec:
        providerConfigRef:
          name: default
        resourceGroupNameSelector:
          matchControllerRef: true
        serverNameSelector:
          matchControllerRef: true
    patches:
    - type: PatchSet
      patchSetName: Metadata
    - fromFieldPath: "spec.parameters.virtualNetworkSubnetId"
      toFieldPath: "spec.properties.virtualNetworkSubnetId"

---
apiVersion: apiextensions.crossplane.io/v1
kind: CompositeResourceDefinition
metadata:
  name: compositepostgresqlinstances.foo.bar
spec:
  connectionSecretKeys:
  - username
  - password
  - hostname
  - port
  - database
  group: foo.bar
  names:
    kind: CompositePostgreSQLInstance
    plural: compositepostgresqlinstances
  claimNames:
    kind: PostgreSQLInstance
    plural: postgresqlinstances
  versions:
  - name: v1alpha1
    served: true
    referenceable: true
    schema:
      openAPIV3Schema:
        type: object
        properties:
          spec:
            type: object
            properties:
              parameters:
                type: object
                properties:
                  version:
                    description: PostgreSQL engine version
                    type: string
                    enum: ["9.5", "9.6", "10", "11"]
                  storageGB:
                    type: integer
                  location:
                    description: Geographic location of this PostgreSQL server.
                    type: string
                  virtualNetworkSubnetId:
                    description: Subnet-Id of your AKS cluster
                    type: string
                  dbName:
                    description: The name of the database
                    type: string
                required:
                - version
                - storageGB
                - location
                - virtualNetworkSubnetId
                - dbName
            required:
            - parameters
```

[contribution process]: https://git.io/fj2m9
