### PR TITLE
Feature/add public access in postgresql

### DIFF
--- a/apis/database/v1beta1/sql_types.go
+++ b/apis/database/v1beta1/sql_types.go
@@ -169,7 +169,7 @@ type SQLServerParameters struct {
 	// must be 'Enabled' or 'Disabled'.
 	// +kubebuilder:validation:Enum=Enabled;Disabled
 	// +optional
-	PublicNetworkAccess string `json:"publicNetworkAccess,omitempty"`
+	PublicNetworkAccess *string `json:"publicNetworkAccess,omitempty"`
 
 	// CreateMode - Possible values include: 'CreateModeDefault', 'CreateModePointInTimeRestore', 'CreateModeGeoRestore', 'CreateModeReplica'
 	// +optional

--- a/apis/database/v1beta1/sql_types.go
+++ b/apis/database/v1beta1/sql_types.go
@@ -199,7 +199,7 @@ type SQLServerParameters struct {
 }
 
 // CreateMode controls the creation behaviour
-// Keep synced with "github.com/Azure/azure-sdk-for-go/services/postgresql/mgmt/2017-12-01/postgresql".MinimalTLSVersionEnum
+// Keep synced with "github.com/Azure/azure-sdk-for-go/services/postgresql/mgmt/2017-12-01/postgresql".CreateMode
 // +kubebuilder:validation:Enum=Default;GeoRestore;PointInTimeRestore;Replica
 type CreateMode string
 

--- a/apis/database/v1beta1/sql_types.go
+++ b/apis/database/v1beta1/sql_types.go
@@ -164,7 +164,12 @@ type SQLServerParameters struct {
 
 	// TODO(hasheddan): support InfrastructureEncryption
 
-	// TODO(hasheddan): support PublicNetworkAccess
+	// PublicNetworkAccess - Whether or not public network access is allowed for
+	// this server. Value is optional but if passed in,
+	// must be 'Enabled' or 'Disabled'.
+	// +kubebuilder:validation:Enum=Enabled;Disabled
+	// +optional
+	PublicNetworkAccess string `json:"publicNetworkAccess,omitempty"`
 
 	// CreateMode - Possible values include: 'CreateModeDefault', 'CreateModePointInTimeRestore', 'CreateModeGeoRestore', 'CreateModeReplica'
 	// +optional

--- a/apis/database/v1beta1/zz_generated.deepcopy.go
+++ b/apis/database/v1beta1/zz_generated.deepcopy.go
@@ -193,6 +193,11 @@ func (in *SQLServerParameters) DeepCopyInto(out *SQLServerParameters) {
 		(*in).DeepCopyInto(*out)
 	}
 	in.SKU.DeepCopyInto(&out.SKU)
+	if in.PublicNetworkAccess != nil {
+		in, out := &in.PublicNetworkAccess, &out.PublicNetworkAccess
+		*out = new(string)
+		**out = **in
+	}
 	if in.CreateMode != nil {
 		in, out := &in.CreateMode, &out.CreateMode
 		*out = new(CreateMode)

--- a/package/crds/database.azure.crossplane.io_mysqlservers.yaml
+++ b/package/crds/database.azure.crossplane.io_mysqlservers.yaml
@@ -73,6 +73,12 @@ spec:
                   minimalTlsVersion:
                     description: MinimalTLSVersion - control TLS connection policy
                     type: string
+                  publicNetworkAccess:
+                    description: PublicNetworkAccess - Whether or not public network access is allowed for this server. Value is optional but if passed in, must be 'Enabled' or 'Disabled'.
+                    enum:
+                    - Enabled
+                    - Disabled
+                    type: string
                   resourceGroupName:
                     description: ResourceGroupName specifies the name of the resource group that should contain this SQLServer.
                     type: string

--- a/package/crds/database.azure.crossplane.io_postgresqlservers.yaml
+++ b/package/crds/database.azure.crossplane.io_postgresqlservers.yaml
@@ -73,6 +73,12 @@ spec:
                   minimalTlsVersion:
                     description: MinimalTLSVersion - control TLS connection policy
                     type: string
+                  publicNetworkAccess:
+                    description: PublicNetworkAccess - Whether or not public network access is allowed for this server. Value is optional but if passed in, must be 'Enabled' or 'Disabled'.
+                    enum:
+                    - Enabled
+                    - Disabled
+                    type: string
                   resourceGroupName:
                     description: ResourceGroupName specifies the name of the resource group that should contain this SQLServer.
                     type: string

--- a/pkg/clients/database/postgresql.go
+++ b/pkg/clients/database/postgresql.go
@@ -84,7 +84,7 @@ func toPGSQLProperties(s v1beta1.SQLServerParameters, adminPassword string) post
 			MinimalTLSVersion:   postgresql.MinimalTLSVersionEnum(s.MinimalTLSVersion),
 			Version:             postgresql.ServerVersion(s.Version),
 			SslEnforcement:      postgresql.SslEnforcementEnum(s.SSLEnforcement),
-			PublicNetworkAccess: postgresql.PublicNetworkAccessEnum(s.PublicNetworkAccess),
+			PublicNetworkAccess: postgresql.PublicNetworkAccessEnum(azure.ToString(s.PublicNetworkAccess)),
 			CreateMode:          postgresql.CreateModePointInTimeRestore,
 			RestorePointInTime:  safeDate(s.RestorePointInTime),
 			SourceServerID:      s.SourceServerID,
@@ -101,7 +101,7 @@ func toPGSQLProperties(s v1beta1.SQLServerParameters, adminPassword string) post
 			Version:             postgresql.ServerVersion(s.Version),
 			SslEnforcement:      postgresql.SslEnforcementEnum(s.SSLEnforcement),
 			SourceServerID:      s.SourceServerID,
-			PublicNetworkAccess: postgresql.PublicNetworkAccessEnum(s.PublicNetworkAccess),
+			PublicNetworkAccess: postgresql.PublicNetworkAccessEnum(azure.ToString(s.PublicNetworkAccess)),
 			CreateMode:          postgresql.CreateModeGeoRestore,
 			StorageProfile: &postgresql.StorageProfile{
 				BackupRetentionDays: azure.ToInt32PtrFromIntPtr(s.StorageProfile.BackupRetentionDays),
@@ -115,7 +115,7 @@ func toPGSQLProperties(s v1beta1.SQLServerParameters, adminPassword string) post
 			MinimalTLSVersion:   postgresql.MinimalTLSVersionEnum(s.MinimalTLSVersion),
 			Version:             postgresql.ServerVersion(s.Version),
 			SslEnforcement:      postgresql.SslEnforcementEnum(s.SSLEnforcement),
-			PublicNetworkAccess: postgresql.PublicNetworkAccessEnum(s.PublicNetworkAccess),
+			PublicNetworkAccess: postgresql.PublicNetworkAccessEnum(azure.ToString(s.PublicNetworkAccess)),
 			CreateMode:          postgresql.CreateModeReplica,
 			SourceServerID:      s.SourceServerID,
 			StorageProfile: &postgresql.StorageProfile{
@@ -134,7 +134,7 @@ func toPGSQLProperties(s v1beta1.SQLServerParameters, adminPassword string) post
 			AdministratorLoginPassword: &adminPassword,
 			Version:                    postgresql.ServerVersion(s.Version),
 			SslEnforcement:             postgresql.SslEnforcementEnum(s.SSLEnforcement),
-			PublicNetworkAccess:        postgresql.PublicNetworkAccessEnum(s.PublicNetworkAccess),
+			PublicNetworkAccess:        postgresql.PublicNetworkAccessEnum(azure.ToString(s.PublicNetworkAccess)),
 			CreateMode:                 postgresql.CreateModeDefault,
 			StorageProfile: &postgresql.StorageProfile{
 				BackupRetentionDays: azure.ToInt32PtrFromIntPtr(s.StorageProfile.BackupRetentionDays),
@@ -179,7 +179,7 @@ func (c *PostgreSQLServerClient) UpdateServer(ctx context.Context, cr *azuredbv1
 		Version:             postgresql.ServerVersion(s.Version),
 		MinimalTLSVersion:   postgresql.MinimalTLSVersionEnum(s.MinimalTLSVersion),
 		SslEnforcement:      postgresql.SslEnforcementEnum(s.SSLEnforcement),
-		PublicNetworkAccess: postgresql.PublicNetworkAccessEnum(s.PublicNetworkAccess),
+		PublicNetworkAccess: postgresql.PublicNetworkAccessEnum(azure.ToString(s.PublicNetworkAccess)),
 		StorageProfile: &postgresql.StorageProfile{
 			BackupRetentionDays: azure.ToInt32PtrFromIntPtr(s.StorageProfile.BackupRetentionDays),
 			GeoRedundantBackup:  postgresql.GeoRedundantBackup(azure.ToString(s.StorageProfile.GeoRedundantBackup)),
@@ -319,8 +319,8 @@ func LateInitializePostgreSQL(p *azuredbv1beta1.SQLServerParameters, in postgres
 		p.SSLEnforcement = string(in.SslEnforcement)
 	}
 
-	if p.PublicNetworkAccess == "" {
-		p.PublicNetworkAccess = string(in.PublicNetworkAccess)
+	if p.PublicNetworkAccess == nil {
+		p.PublicNetworkAccess = azure.ToStringPtr(string(in.PublicNetworkAccess))
 	}
 }
 
@@ -353,7 +353,7 @@ func IsPostgreSQLUpToDate(p azuredbv1beta1.SQLServerParameters, in postgresql.Se
 		return false
 	case azure.ToString(p.StorageProfile.StorageAutogrow) != string(in.StorageProfile.StorageAutogrow):
 		return false
-	case p.PublicNetworkAccess != string(in.PublicNetworkAccess):
+	case azure.ToString(p.PublicNetworkAccess) != string(in.PublicNetworkAccess):
 		return false
 	}
 	return true

--- a/pkg/clients/database/postgresql_test.go
+++ b/pkg/clients/database/postgresql_test.go
@@ -467,33 +467,43 @@ func TestIsPostgreSQLUpToDate(t *testing.T) {
 						Capacity: 2,
 						Family:   "Gen5",
 					},
-					PublicNetworkAccess: "Enabled",
+					PublicNetworkAccess: azure.ToStringPtr("Enabled"),
 					StorageProfile: v1beta1.StorageProfile{
-						StorageMB:       20480,
-						StorageAutogrow: azure.ToStringPtr("Enabled"),
+						StorageMB:           20480,
+						StorageAutogrow:     azure.ToStringPtr("Enabled"),
+						BackupRetentionDays: to.IntPtr(5),
+						GeoRedundantBackup:  azure.ToStringPtr("Disabled"),
 					},
 				},
 				in: postgresql.Server{
+					Tags: map[string]*string{
+						"created_by": azure.ToStringPtr("crossplane"),
+					},
 					Sku: &postgresql.Sku{
 						Tier:     postgresql.GeneralPurpose,
 						Capacity: azure.ToInt32Ptr(2),
 						Family:   azure.ToStringPtr("Gen5"),
 					},
 					ServerProperties: &postgresql.ServerProperties{
+						Version: "9.6",
 						StorageProfile: &postgresql.StorageProfile{
-							StorageMB:       azure.ToInt32Ptr(20480),
-							StorageAutogrow: postgresql.StorageAutogrowEnabled,
+							StorageMB:           azure.ToInt32Ptr(20480),
+							StorageAutogrow:     postgresql.StorageAutogrowEnabled,
+							BackupRetentionDays: azure.ToInt32Ptr(5),
+							GeoRedundantBackup:  postgresql.Disabled,
 						},
+						SslEnforcement:      postgresql.SslEnforcementEnumEnabled,
 						MinimalTLSVersion:   postgresql.TLS12,
 						PublicNetworkAccess: postgresql.PublicNetworkAccessEnumEnabled,
 					},
 				},
 			},
+			want: true,
 		},
 		"IsNotUpToDate": {
 			args: args{
 				p: v1beta1.SQLServerParameters{
-					PublicNetworkAccess: "Disabled",
+					PublicNetworkAccess: azure.ToStringPtr("Disabled"),
 				},
 				in: postgresql.Server{
 					Sku: &postgresql.Sku{},
@@ -548,7 +558,7 @@ func TestLateInitializePostgreSQL(t *testing.T) {
 				},
 			},
 			want: &v1beta1.SQLServerParameters{
-				PublicNetworkAccess: "Enabled",
+				PublicNetworkAccess: azure.ToStringPtr("Enabled"),
 			},
 		},
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Add support to PublicNetworkAccess field in PostgreSQLServer only.

This implementation is initially for internal use within Stone. For this reason that there is only an implementation for PostgreSQL and not MySQL. The burden of this is that the field is available in MySQL due to the structure of the types and is completely ignored in the MySQLServer CRD.

Fixes https://github.com/crossplane/provider-azure/issues/240

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

- Unit tests
- Manually tested

### Disclaimer

Before to test see https://github.com/stone-payments/provider-azure/pull/3 talk about a bug that affect this change.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
