### PR TITLE
Fix panic when returning error with provider reference name

### DIFF
--- a/apis/storage/v1alpha3/test/container.go
+++ b/apis/storage/v1alpha3/test/container.go
@@ -93,6 +93,12 @@ func (tc *MockContainer) WithSpecProviderRef(name string) *MockContainer {
 	return tc
 }
 
+// WithSpecProviderConfigRef sets spec account reference value
+func (tc *MockContainer) WithSpecProviderConfigRef(name string) *MockContainer {
+	tc.Container.Spec.ProviderConfigReference = &xpv1.Reference{Name: name}
+	return tc
+}
+
 // WithSpecDeletionPolicy sets spec deletion policy value
 func (tc *MockContainer) WithSpecDeletionPolicy(p xpv1.DeletionPolicy) *MockContainer {
 	tc.Container.Spec.DeletionPolicy = p

--- a/pkg/controller/storage/container/container.go
+++ b/pkg/controller/storage/container/container.go
@@ -155,7 +155,7 @@ func (m *containerSyncdeleterMaker) newSyncdeleter(ctx context.Context, c *v1alp
 				return nil, errors.Wrapf(err, "failed to update after removing finalizer")
 			}
 		}
-		return nil, errors.Wrapf(err, "failed to retrieve storage account: %s", c.Spec.ProviderReference.Name)
+		return nil, errors.Wrapf(err, "failed to retrieve storage account: %s", nn.Name)
 	}
 
 	if acct.GetWriteConnectionSecretToReference() == nil {

--- a/pkg/controller/storage/container/container_test.go
+++ b/pkg/controller/storage/container/container_test.go
@@ -314,7 +314,7 @@ func Test_containerSyncdeleterMaker_newSyncdeleter(t *testing.T) {
 		want   want
 	}{
 		{
-			name: "FailedToGetAccountNotFoundNoDelete",
+			name: "FailedToGetAccountNotFoundNoDeleteProviderRef",
 			fields: fields{
 				Client: &test.MockClient{
 					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -325,6 +325,24 @@ func Test_containerSyncdeleterMaker_newSyncdeleter(t *testing.T) {
 			args: args{
 				ctx: ctx,
 				c:   newCont().WithSpecProviderRef(testAccountName).WithFinalizer(finalizer).Container,
+			},
+			want: want{
+				err: errors.Wrapf(newAccountNotFoundError(testAccountName),
+					"failed to retrieve storage account: %s", testAccountName),
+			},
+		},
+		{
+			name: "FailedToGetAccountNotFoundNoDeleteProviderConfigRef",
+			fields: fields{
+				Client: &test.MockClient{
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						return newAccountNotFoundError(testAccountName)
+					},
+				},
+			},
+			args: args{
+				ctx: ctx,
+				c:   newCont().WithSpecProviderConfigRef(testAccountName).WithFinalizer(finalizer).Container,
 			},
 			want: want{
 				err: errors.Wrapf(newAccountNotFoundError(testAccountName),


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes a panic in the storage container controller that used the provider
reference name in the error when we are unable to get the storage
account that serves as this type's provider. The ProviderReference may
be nil in the case that the newer ProviderConfigReference is used.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes https://github.com/crossplane/provider-azure/issues/248

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

I have not tested this change extensively, but I have a high degree of confidence in the fix given the observed stack trace on panic:

```
goroutine 692 [running]:
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/home/runner/work/provider-azure/provider-azure/.work/pkg/pkg/mod/k8s.io/apimachinery@v0.20.1/pkg/util/runtime/runtime.go:55 +0x109
panic(0x197c8e0, 0x2993560)
	/opt/hostedtoolcache/go/1.16.7/x64/src/runtime/panic.go:965 +0x1b9
github.com/crossplane/provider-azure/pkg/controller/storage/container.(*containerSyncdeleterMaker).newSyncdeleter(0xc0003783e0, 0x1dde980, 0xc0002f0300, 0xc00028a480, 0xdf8475800, 0x0, 0x0, 0x1e0ab80, 0xc00028a480)
	/home/runner/work/provider-azure/provider-azure/pkg/controller/storage/container/container.go:158 +0x9d1
github.com/crossplane/provider-azure/pkg/controller/storage/container.(*Reconciler).Reconcile(0xc0002d75c0, 0x1dde9b8, 0xc0002f0300, 0x0, 0x0, 0xc0000c4600, 0x11, 0xc000b6b800, 0x0, 0x0, ...)
	/home/runner/work/provider-azure/provider-azure/pkg/controller/storage/container/container.go:114 +0x3a8
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc000268a00, 0x1dde910, 0xc0000c6000, 0x19df200, 0xc000b63100)
	/home/runner/work/provider-azure/provider-azure/.work/pkg/pkg/mod/sigs.k8s.io/controller-runtime@v0.8.0/pkg/internal/controller/controller.go:293 +0x30d
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc000268a00, 0x1dde910, 0xc0000c6000, 0xc00025de00)
	/home/runner/work/provider-azure/provider-azure/.work/pkg/pkg/mod/sigs.k8s.io/controller-runtime@v0.8.0/pkg/internal/controller/controller.go:248 +0x205
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1.1(0x1dde910, 0xc0000c6000)
	/home/runner/work/provider-azure/provider-azure/.work/pkg/pkg/mod/sigs.k8s.io/controller-runtime@v0.8.0/pkg/internal/controller/controller.go:211 +0x4a
k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext.func1()
	/home/runner/work/provider-azure/provider-azure/.work/pkg/pkg/mod/k8s.io/apimachinery@v0.20.1/pkg/util/wait/wait.go:185 +0x37
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc00025df50)
	/home/runner/work/provider-azure/provider-azure/.work/pkg/pkg/mod/k8s.io/apimachinery@v0.20.1/pkg/util/wait/wait.go:155 +0x5f
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc000703f50, 0x1daa3c0, 0xc0005a8cc0, 0xc0000c6001, 0xc00032c120)
	/home/runner/work/provider-azure/provider-azure/.work/pkg/pkg/mod/k8s.io/apimachinery@v0.20.1/pkg/util/wait/wait.go:156 +0x9b
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc00025df50, 0x3b9aca00, 0x0, 0x993f01, 0xc00032c120)
	/home/runner/work/provider-azure/provider-azure/.work/pkg/pkg/mod/k8s.io/apimachinery@v0.20.1/pkg/util/wait/wait.go:133 +0x98
k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext(0x1dde910, 0xc0000c6000, 0xc0007de880, 0x3b9aca00, 0x0, 0x1)
	/home/runner/work/provider-azure/provider-azure/.work/pkg/pkg/mod/k8s.io/apimachinery@v0.20.1/pkg/util/wait/wait.go:185 +0xa6
k8s.io/apimachinery/pkg/util/wait.UntilWithContext(0x1dde910, 0xc0000c6000, 0xc0007de880, 0x3b9aca00)
	/home/runner/work/provider-azure/provider-azure/.work/pkg/pkg/mod/k8s.io/apimachinery@v0.20.1/pkg/util/wait/wait.go:99 +0x57
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1
	/home/runner/work/provider-azure/provider-azure/.work/pkg/pkg/mod/sigs.k8s.io/controller-runtime@v0.8.0/pkg/internal/controller/controller.go:208 +0x49e
```

I have also added a unit test that confirms that panic does occur prior to the change, and does not after.

[contribution process]: https://git.io/fj2m9
