### PR TITLE
Ignore minimalTlsVersion mismatch when the sslEnforcement is disabled

### DIFF
--- a/examples/database/postgresqlserver.yaml
+++ b/examples/database/postgresqlserver.yaml
@@ -11,8 +11,8 @@ spec:
     resourceGroupNameRef:
       name: example-rg
     location: West US 2
-    minimalTlsVersion: TLS12
-    sslEnforcement: Disabled
+    minimalTlsVersion: TLS1_2
+    sslEnforcement: Enabled
     version: "9.6"
     sku:
       # Note that Basic servers do not support virtual network rules

--- a/pkg/clients/database/mysql.go
+++ b/pkg/clients/database/mysql.go
@@ -338,7 +338,7 @@ func IsMySQLUpToDate(p azuredbv1beta1.SQLServerParameters, in mysql.Server) bool
 		return false
 	}
 	switch {
-	case p.MinimalTLSVersion != string(in.MinimalTLSVersion):
+	case p.MinimalTLSVersion != string(in.MinimalTLSVersion) && p.SSLEnforcement != string(mysql.SslEnforcementEnumDisabled):
 		return false
 	case p.SSLEnforcement != string(in.SslEnforcement):
 		return false

--- a/pkg/clients/database/postgresql.go
+++ b/pkg/clients/database/postgresql.go
@@ -331,7 +331,7 @@ func IsPostgreSQLUpToDate(p azuredbv1beta1.SQLServerParameters, in postgresql.Se
 		return false
 	}
 	switch {
-	case p.MinimalTLSVersion != string(in.MinimalTLSVersion):
+	case p.MinimalTLSVersion != string(in.MinimalTLSVersion) && p.SSLEnforcement != string(postgresql.SslEnforcementEnumDisabled):
 		return false
 	case p.SSLEnforcement != string(in.SslEnforcement):
 		return false


### PR DESCRIPTION
Signed-off-by: Sergen Yalçın <yalcinsergen97@gmail.com>

### Description of your changes

Fixes #307 

This PR solves the problem that `IsPostgreSQLUpToDate` function always returns false. When the value of `sslEnforcement` is `Disabled`, the `minimalTlsVersion` mismatch is ignored.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

- A PostgreSqlServer was provisioned by using example manifest (value of `sslEnforcement` is `Disabled`). Then I observed that, the `IsPostgreSQLUpToDate` returned true despite there is a mismatch between the values of `minimalTlsVersion`.

- A PostgreSqlServer was provisioned by using example manifest (value of `sslEnforcement` is `Enabled`, value of `minimalTlsVersion` is `TLS1_2`). Then I observed that, cloud resource created with proper values and `IsPostgreSQLUpToDate` did not return false.

[contribution process]: https://git.io/fj2m9
