### PR TITLE
Fix AKSCluster doc comment typo

### DIFF
--- a/apis/compute/v1alpha3/types.go
+++ b/apis/compute/v1alpha3/types.go
@@ -52,10 +52,10 @@ type AKSClusterParameters struct {
 	// +optional
 	VnetSubnetID string `json:"vnetSubnetID,omitempty"`
 
-	// ResourceGroupNameRef - A reference to a Subnet to retrieve its ID
+	// VnetSubnetIDRef - A reference to a Subnet to retrieve its ID
 	VnetSubnetIDRef *xpv1.Reference `json:"vnetSubnetIDRef,omitempty"`
 
-	// ResourceGroupNameSelector - Select a reference to a Subnet to retrieve
+	// VnetSubnetIDSelector - Select a reference to a Subnet to retrieve
 	// its ID
 	VnetSubnetIDSelector *xpv1.Selector `json:"vnetSubnetIDSelector,omitempty"`
 

--- a/package/crds/compute.azure.crossplane.io_aksclusters.yaml
+++ b/package/crds/compute.azure.crossplane.io_aksclusters.yaml
@@ -125,7 +125,7 @@ spec:
                 description: VnetSubnetID is the subnet to which the cluster will be deployed.
                 type: string
               vnetSubnetIDRef:
-                description: ResourceGroupNameRef - A reference to a Subnet to retrieve its ID
+                description: VnetSubnetIDRef - A reference to a Subnet to retrieve its ID
                 properties:
                   name:
                     description: Name of the referenced object.
@@ -134,7 +134,7 @@ spec:
                 - name
                 type: object
               vnetSubnetIDSelector:
-                description: ResourceGroupNameSelector - Select a reference to a Subnet to retrieve its ID
+                description: VnetSubnetIDSelector - Select a reference to a Subnet to retrieve its ID
                 properties:
                   matchControllerRef:
                     description: MatchControllerRef ensures an object with the same controller reference as the selecting object is selected.


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes doc string typos in the subnet referencer fields of the `AKSCluster` MR.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Ran `make generate` to observe doc string changes.

[contribution process]: https://git.io/fj2m9
