### PR TITLE
Reuse generated password for AKSCluster's Application

### DIFF
--- a/pkg/clients/compute/aks.go
+++ b/pkg/clients/compute/aks.go
@@ -189,7 +189,7 @@ func (c AggregateClient) ensureApplication(ctx context.Context, name, secret str
 		return l.Value(), nil // nolint:staticcheck
 	}
 
-	url := fmt.Sprintf("https://%s.aks.crossplane.io", name)
+	url := fmt.Sprintf("api://%s.aks.crossplane.io", name)
 	p := graphrbac.ApplicationCreateParameters{
 		AvailableToOtherTenants: to.BoolPtr(false),
 		DisplayName:             to.StringPtr(name),


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #298

This PR proposes a change in the AKSCluster's reconciler where we reuse the graph Application's password credential across reconciliations instead of regenerating a brand new password each time.

With this PR, we also change the scheme of the associated graph Application's App ID URI from `https` to `api`. See [here](https://github.com/crossplane/provider-azure/issues/298#issuecomment-972550233) for a detailed account on this matter.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Successfully provisioned an AKSCluster in 5 of the 5 trials.

[contribution process]: https://git.io/fj2m9
