### PR TITLE
Actually cache the go build cache between CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Find the Go Build Cache
         id: go
-        run: echo "::set-output name=cache::$(go env GOCACHE)"
+        run: echo "::set-output name=cache::$(make go.cachedir)"
 
       - name: Cache the Go Build Cache
         uses: actions/cache@v2
@@ -94,7 +94,7 @@ jobs:
 
       - name: Find the Go Build Cache
         id: go
-        run: echo "::set-output name=cache::$(go env GOCACHE)"
+        run: echo "::set-output name=cache::$(make go.cachedir)"
 
       - name: Cache the Go Build Cache
         uses: actions/cache@v2
@@ -137,7 +137,7 @@ jobs:
 
       - name: Find the Go Build Cache
         id: go
-        run: echo "::set-output name=cache::$(go env GOCACHE)"
+        run: echo "::set-output name=cache::$(make go.cachedir)"
 
       - name: Cache the Go Build Cache
         uses: actions/cache@v2
@@ -197,7 +197,7 @@ jobs:
 
       - name: Find the Go Build Cache
         id: go
-        run: echo "::set-output name=cache::$(go env GOCACHE)"
+        run: echo "::set-output name=cache::$(make go.cachedir)"
 
       - name: Cache the Go Build Cache
         uses: actions/cache@v2
@@ -259,7 +259,7 @@ jobs:
 
       - name: Find the Go Build Cache
         id: go
-        run: echo "::set-output name=cache::$(go env GOCACHE)"
+        run: echo "::set-output name=cache::$(make go.cachedir)"
 
       - name: Cache the Go Build Cache
         uses: actions/cache@v2

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,14 @@ fallthrough: submodules
 	@echo Initial setup complete. Running make again . . .
 	@make
 
+# NOTE(hasheddan): the build submodule currently overrides XDG_CACHE_HOME in
+# order to force the Helm 3 to use the .work/helm directory. This causes Go on
+# Linux machines to use that directory as the build cache as well. We should
+# adjust this behavior in the build submodule because it is also causing Linux
+# users to duplicate their build cache, but for now we just make it easier to
+# identify its location in CI so that we cache between builds.
+go.cachedir:
+	@go env GOCACHE
 
 # Generate a coverage report for cobertura applying exclusions on
 # - generated file


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->


The build submodule currently overrides XDG_CACHE_HOME in
order to force the Helm 3 to use the .work/helm directory. This causes Go on
Linux machines to use that directory as the build cache as well. We should
adjust this behavior in the build submodule because it is also causing Linux
users to duplicate their build cache, but for now we just make it easier to
identify its location in CI so that we cache between builds.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Updates CI workflow to cache based on go.cachedir to work around the
fact that we override the GOCACHE in our make context due to the
inclusion of helm.mk.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

See https://github.com/crossplane/crossplane/pull/2742 for more details -- we are seeing drastic improvements (as would be expected now that we are actually caching) in Crossplane CI. 

[contribution process]: https://git.io/fj2m9
