### PR TITLE
Add nil check for IPConfigurationPropertiesFormat

### DIFF
--- a/pkg/clients/network/network.go
+++ b/pkg/clients/network/network.go
@@ -182,7 +182,7 @@ func GeneratePublicIPAddressObservation(az networkmgmt.PublicIPAddress) *v1alpha
 	v.ID = azure.ToString(az.ID)
 	v.Address = azure.ToString(az.IPAddress)
 	v.Version = string(az.PublicIPAddressVersion)
-	if az.IPConfiguration != nil {
+	if az.PublicIPAddressPropertiesFormat != nil && az.PublicIPAddressPropertiesFormat.IPConfiguration != nil && az.PublicIPAddressPropertiesFormat.IPConfiguration.IPConfigurationPropertiesFormat != nil {
 		v.IPConfiguration = &v1alpha3.IPConfiguration{
 			PrivateIPAllocationMethod: string(az.IPConfiguration.PrivateIPAllocationMethod),
 			PrivateIPAddress:          az.IPConfiguration.PrivateIPAddress,


### PR DESCRIPTION
### Description of your changes

This PR fixes the nil pointer issue for the PublicIPAddress resource. When IPConfiguration field is not nil, we need to check whether the IPConfigurationPropertiesFormat (embedded) is nil because we are trying to access the fields of the embedded struct. For example; `PrivateIPAllocationMethod`, `PrivateIPAddress`, `ProvisioningState`.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

This PR was tested by filling manually the IPConfiguration field. Then the nil pointer issue was not observed.

[contribution process]: https://git.io/fj2m9
